### PR TITLE
Add support for annotations on annotations

### DIFF
--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -986,9 +986,9 @@ mod test {
     }
 
     #[test]
-    fn round_annotation_on_annotation() {
+    fn round_annotation_on_annotation_assertion() {
         assert_round(include_str!(
-            "../ont/owl-xml/annotation-with-annotation.owl"
+            "../ont/owl-xml/annotation-assertion-with-annotation.owl"
         ));
     }
 

--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -308,6 +308,19 @@ impl<'a, A: Render<'a, W>, B: Render<'a, W>, C: Render<'a, W>, W: StdWrite> Rend
     }
 }
 
+impl<'a, A: Render<'a, W>, B: Render<'a, W>, C: Render<'a, W>, D: Render<'a, W>, W: StdWrite> Render<'a, W>
+    for (&'a A, &'a B, &'a C, &'a D)
+{
+    fn render(&self, w: &mut Writer<W>, m: &'a PrefixMapping) -> Result<(), Error> {
+        (&self.0).render(w, m)?;
+        (&self.1).render(w, m)?;
+        (&self.2).render(w, m)?;
+        (&self.3).render(w, m)?;
+
+        Ok(())
+    }
+}
+
 render!{
     PrefixMapping, self, w, _m,
     {
@@ -543,7 +556,8 @@ render! {
 }
 
 contents!{OntologyAnnotation, self,
-         (&self.0.annotation_property,
+         (&self.0.annotation,
+          &self.0.annotation_property,
           &self.0.annotation_value)
 }
 
@@ -630,7 +644,8 @@ contents!{
 
 contents!{
     AnnotationAssertion, self,
-        (&self.annotation.annotation_property,
+        (&self.annotation.annotation,
+         &self.annotation.annotation_property,
          &self.annotation_subject,
          &self.annotation.annotation_value)
 }
@@ -681,7 +696,8 @@ render!{
 render!{
     Annotation, self, w, m,
     {
-        (&self.annotation_property,
+        (&self.annotation,
+         &self.annotation_property,
          &self.annotation_value).
             within(w, m, b"Annotation")?;
 
@@ -989,6 +1005,13 @@ mod test {
     fn round_annotation_on_annotation_assertion() {
         assert_round(include_str!(
             "../ont/owl-xml/annotation-assertion-with-annotation.owl"
+        ));
+    }
+
+    #[test]
+    fn round_annotation_on_annotation() {
+        assert_round(include_str!(
+            "../ont/owl-xml/annotation-with-annotation.owl"
         ));
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -991,6 +991,7 @@ pub struct Literal {
 /// particular way, defined by the property.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Annotation {
+    pub annotation: BTreeSet<Annotation>,
     pub annotation_property: AnnotationProperty,
     pub annotation_value: AnnotationValue,
 }

--- a/src/ont/owl-xml/annotation-assertion-with-annotation.owl
+++ b/src/ont/owl-xml/annotation-assertion-with-annotation.owl
@@ -14,14 +14,19 @@
     <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
     <Prefix name="pattern" IRI="http://www.w3id.org/ontolink/pattern.owl#"/>
     <Declaration>
-        <Annotation>
-            <Annotation>
-              <AnnotationProperty IRI="oboInOwl:hasDbXref"/>
-              <IRI>https://www.ncbi.nlm.nih.gov/pubmed/31014809</IRI>
-            </Annotation>
-            <AnnotationProperty IRI="oboInOwl:Definition"/>
-            <Literal datatypeIRI="xsd:string">Something something</Literal>
-        </Annotation>
-        <Class IRI="http://purl.obolibrary.org/obo/TST_001"/>
+      <Class IRI="#A"/>
     </Declaration>
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+            <Literal
+                datatypeIRI="http://www.w3.org/2001/XMLSchema#string">Comment
+            on Comment</Literal>
+        </Annotation>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>#C</AbbreviatedIRI>
+        <Literal
+            datatypeIRI="http://www.w3.org/2001/XMLSchema#string">Comment
+        on Class</Literal>
+    </AnnotationAssertion>
 </Ontology>


### PR DESCRIPTION
Fixes #1.

I also added some tests to make sure this works as intended; now I should be able to have proper OBO to OWL mapping implemented in pure Rust!