### PR TITLE
Write CURIEs in `AbbreviatedIRI` XML elements instead of `IRI`

### DIFF
--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -71,7 +71,7 @@ fn attribute_maybe(elem: &mut BytesStart, key: &str, val: &Option<String>) {
     }
 }
 
-/// Add an IRI or abbreviatedIRI attribute to elem
+/// Add an IRI or AbbreviatedIRI attribute to elem
 fn iri_or_curie<'a>(mapping: &'a PrefixMapping, elem: &mut BytesStart, iri: &str) {
     match mapping.shrink_iri(&(*iri)[..]) {
         Ok(curie) => {
@@ -334,9 +334,11 @@ render!{
     IRI, self, w, m,
     {
         let iri_st: String = self.into();
-        let iri_shrunk = shrink_iri_maybe(&iri_st[..], m);
-        iri_shrunk.within(w, m, b"IRI")?;
-        Ok(())
+
+        match m.shrink_iri(&iri_st[..]) {
+            Ok(curie) => curie.to_string().within(w, m, b"AbbreviatedIRI"),
+            Err(_) => iri_st.within(w, m, b"IRI"),
+        }
     }
 }
 


### PR DESCRIPTION
Ok, so this one addresses a real issue: the current writer exports both IRIs and CURIEs into an `<IRI>` element whereas the specs expect an `<AbbreviatedIRI>` tag in the case of CURIEs. This causes Protégé to fail expanding CURIEs because it assumes the `<IRI>` element contains an expanded IRI already.