### PR TITLE
Add `AsRef<str>` impl for `model::IRI`

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -19,6 +19,12 @@ use std::rc::Rc;
 #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct IRI(Rc<String>);
 
+impl AsRef<str> for IRI {
+    fn as_ref(&self) -> &str {
+        &self.0.as_str()
+    }
+}
+
 impl Deref for IRI {
     type Target = String;
 


### PR DESCRIPTION
This allows using IRI in many places that expect strings (`AsRef<str>` is the most common way to mark that). It could also be interesting to add a `Borrow` implementation for `IRI`.