### PR TITLE
Make sure to escape and unescape literal text in XML I/O code

### DIFF
--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -325,7 +325,7 @@ render!{
 render!{
     String, self, w, _m,
     {
-        w.write_event(Event::Text(BytesText::from_escaped_str(&self[..])))?;
+        w.write_event(Event::Text(BytesText::from_plain_str(&self[..])))?;
         Ok(())
     }
 }
@@ -1000,6 +1000,11 @@ mod test {
     #[test]
     fn round_data_property() {
         assert_round(include_str!("../ont/owl-xml/data-property.owl"));
+    }
+
+    #[test]
+    fn round_literal_escaped() {
+        assert_round(include_str!("../ont/owl-xml/literal-escaped.owl"));
     }
 
     #[test]

--- a/src/ont/owl-xml/literal-escaped.owl
+++ b/src/ont/owl-xml/literal-escaped.owl
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="http://www.example.com"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="http://www.example.com">
+    <Prefix name="o" IRI="http://www.example.com#"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+    <Prefix name="pattern" IRI="http://www.w3id.org/ontolink/pattern.owl#"/>
+    <Declaration>
+      <Class IRI="#A"/>
+    </Declaration>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>#C</AbbreviatedIRI>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#string">A --&gt; B</Literal>
+    </AnnotationAssertion>
+</Ontology>


### PR DESCRIPTION
Current implementation does not decode and encode literal values, which is a pain for users since they are expected to do all the XML escaping themselves. This PR changes the implementation of `from_start! { Literal .. }` to use `read_text` so that the reader unescapes the literal value, and the writer was patched to expect an unescaped string in lieu of an escaped one.

I'm also not sure why `literal` is an `Option` in `Literal`, since the `None` type is here semantically equivalent to an empty string when serializing and deserializing.

~~*Also sorry for the large diff but I didn't realise I had `rustfmt` turned on in my IDE before pushing the commit*~~ Rebased and made a minimal commit without format changes.