### PR TITLE
Bumps "quick_xml" crate to latest version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ enum_meta = "0.6.0"
 failure = "0.1.2"
 lazy_static="1.4.0"
 log = {version="0.4.8"}
-quick-xml="0.12.4"
+quick-xml = { version = "0.22.0", features = [ "encoding" ] }
 indexmap="1.0.2"
 sophia = {version="0.5.3", features=["xml"]}
 


### PR DESCRIPTION
Adding the "encoding" feature ensures that bumping to latest version does not break compilation.