### PR TITLE
Introduces error handling for ParserOutput.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,3 +4,10 @@ pub enum CommandError {
     #[fail(display = "An argument that was expected is missing")]
     MissingArgument,
 }
+
+/// Errors issued while parsing ontologies.
+#[derive(Debug, Fail)]
+pub enum ParserError {
+    #[fail(display = "Do not know how to parse file with path: {:?}", path)]
+    FormatNotSupported{ path: Box<std::path::Path> }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,7 +3,6 @@
 pub mod owx;
 pub mod rdf;
 
-
 use curie::PrefixMapping;
 
 use crate::ontology
@@ -11,7 +10,6 @@ use crate::ontology
        set::SetOntology};
 
 use self::rdf::reader::{IncompleteParse, RDFOntology};
-
 
 pub enum ResourceType{OWX, RDF}
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -30,7 +30,7 @@ pub fn resolve_iri(iri:&IRI, doc_iri: &IRI) -> Vec<u8> {
     strict_resolve_iri(&localize_iri(iri, doc_iri))
 }
 
-// Return the ontology as Vec<u8> from `iri`.
+/// Return the ontology as Vec<u8> from `iri`.
 pub fn strict_resolve_iri(iri: &IRI) -> Vec<u8> {
     let mut data = Vec::new();
     let mut handle = Easy::new();


### PR DESCRIPTION
Introduced enum ParserError, for now handling only cases where an unsupported extension is found.
The enum is added to the 'error' module.
Routines in 'command' have been updated to make use of the error.