### PR TITLE
Fix rendering of `AnnotationAssertion` subjects in OWL/XML writer

### DIFF
--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -642,11 +642,21 @@ contents! {
     ClassAssertion, self, (&self.ce, &self.i)
 }
 
-contents! {
-    AnnotationAssertion, self,
-    (&self.ann.ap,
-     &self.subject,
-     &self.ann.av)
+render! {
+    AnnotationAssertion, self, w, m,
+    {
+        (&self.ann.ap).render(w, m)?;
+        if let Individual::Named(named) = &self.subject {
+            // render in an <IRI> or <abbreviatedIRI> tag directly
+            named.0.render(w, m)?;
+        } else {
+            // render in an <AnonymousIndividual> tag
+            self.subject.render(w, m)?;
+        }
+        (&self.ann.av).render(w, m)?;
+
+        Ok(())
+    }
 }
 
 render! {


### PR DESCRIPTION
Hi Phil, it's been a while!

While working on the `fastobo-owl` crate (which I'll release soon), I noticed the following bug with the XML writer.

Currently, it will write a `NamedIndividual` element when serializing an `AnnotationAssertion` axiom:
```xml
    <AnnotationAssertion>
        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#id"/>
        <NamedIndividual IRI="http://purl.obolibrary.org/obo/MS_0000000"/>
        <Literal>MS:0000000</Literal>
    </AnnotationAssertion>
```

However according to the [OWL2 specs](https://www.w3.org/TR/owl2-syntax/#Annotation_Assertion) the IRI must be written directly, and the file above will fail to be processed by the OWL API parser. The correct element should be:
```xml
    <AnnotationAssertion>
        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#id"/>
        <IRI>http://purl.obolibrary.org/obo/MS_0000000</IRI>
        <Literal>MS:0000000</Literal>
    </AnnotationAssertion>
```

I fixed the parser to render correctly, but I'm wondering if the `subject` field of `AnnotationAssertion` axiom shouldn't be it's own type (with the same variants as a `NamedIndividual`) to avoid future confusion like this.