### PR TITLE
Improve `Builder` interface to allow skipping copy when possible

### DIFF
--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -161,7 +161,7 @@ trait Convert {
 
 impl Convert for rio_api::model::NamedNode<'_> {
     fn to_iri(&self, b: &Build) -> IRI {
-        b.iri(&self.to_string())
+        b.iri(&self.iri)
     }
 }
 
@@ -255,7 +255,7 @@ fn to_term_lt<'a>(lt: &'a rio_api::model::Literal, b: &Build)-> Term {
             Term::Literal(Literal::Simple{literal: value.to_string()}),
         rio_api::model::Literal::Typed { value, datatype } => {
             Term::Literal(Literal::Datatype{literal: value.to_string(),
-                                            datatype_iri: b.iri(datatype.iri.to_string())})
+                                            datatype_iri: b.iri(datatype.iri)})
         }
     }
 }

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -204,40 +204,39 @@ impl From<Term> for OrTerm {
     }
 }
 
-fn vocab_lookup() -> HashMap<&'static String, Term> {
+fn vocab_lookup() -> HashMap<&'static str, Term> {
     let mut m = HashMap::default();
 
     for v in VOWL::all() {
         match v {
             // Skip the builtin properties or we have to treat them separately
             VOWL::TopDataProperty => None,
-            _ => m.insert(v.iri_s(), Term::OWL(v)),
+            _ => m.insert(v.iri_s().as_str(), Term::OWL(v)),
         };
     }
 
     for v in VRDFS::all() {
-        m.insert(v.iri_s(), Term::RDFS(v));
+        m.insert(v.iri_s().as_str(), Term::RDFS(v));
     }
 
     for v in VRDF::all() {
-        m.insert(v.iri_s(), Term::RDF(v));
+        m.insert(v.iri_s().as_str(), Term::RDF(v));
     }
 
     for v in Facet::all() {
-        m.insert(v.iri_s(), Term::FacetTerm(v));
+        m.insert(v.iri_s().as_str(), Term::FacetTerm(v));
     }
     m
 }
 
 
 fn to_term_nn<'a>(nn: &'a NamedNode,
-                  m: &HashMap<&String, Term>,
+                  m: &HashMap<&str, Term>,
                   b: &Build) -> Term {
-    let s = nn.iri.to_string();
-    if let Some(term) = m.get(&s) {
+    if let Some(term) = m.get(&nn.iri) {
         return term.clone();
     }
-    Term::Iri(b.iri(s))
+    Term::Iri(b.iri(nn.iri))
 }
 
 fn to_term_bn<'a>(nn: &'a BlankNode) -> Term {
@@ -261,7 +260,7 @@ fn to_term_lt<'a>(lt: &'a rio_api::model::Literal, b: &Build)-> Term {
 }
 
 fn to_term_nnb<'a>(nnb: &'a Subject,
-                   m: &HashMap<&String, Term>,
+                   m: &HashMap<&str, Term>,
                    b: &Build) -> Term {
     match nnb {
         Subject::NamedNode(nn) => {
@@ -275,7 +274,7 @@ fn to_term_nnb<'a>(nnb: &'a Subject,
     }
 }
 
-fn to_term<'a>(t: &'a RioTerm, m: &HashMap<&String, Term>, b: &Build) -> Term {
+fn to_term<'a>(t: &'a RioTerm, m: &HashMap<&str, Term>, b: &Build) -> Term {
     match t {
         rio_api::model::Term::NamedNode(iri) => to_term_nn(iri, m, b),
         rio_api::model::Term::BlankNode(id) => to_term_bn(id),

--- a/src/model.rs
+++ b/src/model.rs
@@ -189,18 +189,17 @@ impl Build {
     /// ```
     pub fn iri<S>(&self, s: S) -> IRI
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
-        let s:String = s.into();
-        let iri = IRI(s.into());
-
         let mut cache = self.0.borrow_mut();
-        if cache.contains(&iri) {
-            return cache.get(&iri).unwrap().clone();
+        if let Some(iri) = cache.get(s.as_ref()) {
+            iri.clone()
+        } else {
+            let iri = IRI(Rc::from(s.as_ref()));
+            cache.insert(iri.clone());
+            iri
         }
 
-        cache.insert(iri.clone());
-        iri
     }
 
     /// Constructs a new `Class`.
@@ -219,7 +218,7 @@ impl Build {
     ///
     pub fn class<S>(&self, s: S) -> Class
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
         Class(self.iri(s))
     }
@@ -238,7 +237,7 @@ impl Build {
     /// ```
     pub fn object_property<S>(&self, s: S) -> ObjectProperty
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
         ObjectProperty(self.iri(s))
     }
@@ -257,7 +256,7 @@ impl Build {
     /// ```
     pub fn annotation_property<S>(&self, s: S) -> AnnotationProperty
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
         AnnotationProperty(self.iri(s))
     }
@@ -276,7 +275,7 @@ impl Build {
     /// ```
     pub fn data_property<S>(&self, s: S) -> DataProperty
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
         DataProperty(self.iri(s))
     }
@@ -295,7 +294,7 @@ impl Build {
     /// ```
     pub fn named_individual<S>(&self, s: S) -> NamedIndividual
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
         NamedIndividual(self.iri(s))
     }
@@ -314,7 +313,7 @@ impl Build {
     /// ```
     pub fn datatype<S>(&self, s: S) -> Datatype
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
         Datatype(self.iri(s))
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -90,10 +90,12 @@
 //! };
 //! ```
 
-use std::{cell::RefCell, fmt::Formatter};
+use std::borrow::Borrow;
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fmt::Display;
+use std::fmt::Formatter;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::ops::Deref;
@@ -120,6 +122,12 @@ impl Deref for IRI {
 impl AsRef<str> for IRI {
     fn as_ref(&self) -> &str {
         &self.0.as_ref()
+    }
+}
+
+impl Borrow<str> for IRI {
+    fn borrow(&self) -> &str {
+        self.as_ref()
     }
 }
 


### PR DESCRIPTION
Hi again, this time with a smaller PR to improve the way `Build` creates IRI strings.

In the current version of the code, `Build::iri` would always copy the string passed as argument to a new buffer, even when the cache was hit, because it needed an `IRI` struct to check for membership in the cache. Which means that every call to `Build::iri` was copying the string contents.

By implementing `Borrow<str>` for IRI, you can now check whether the IRI is already in the cache simply by comparing to its string value. This means `Build::iri` (and associated methods) can be updated to take any `AsRef<str>` implementor.




