### PR TITLE
Update `horned_owl::io::owx::writer::write` to use a generic argument

### DIFF
--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -59,16 +59,16 @@ where
     ns_buf: Vec<u8>,
 }
 
-pub fn read<R: BufRead>(bufread: &mut R) -> Result<(Ontology, PrefixMapping), Error> {
+pub fn read<R: BufRead>(bufread: R) -> Result<(Ontology, PrefixMapping), Error> {
     let b = Build::new();
     read_with_build(bufread, &b)
 }
 
 pub fn read_with_build<R: BufRead>(
-    bufread: &mut R,
+    bufread: R,
     build: &Build,
 ) -> Result<(Ontology, PrefixMapping), Error> {
-    let reader: Reader<&mut R> = Reader::from_reader(bufread);
+    let reader: Reader<R> = Reader::from_reader(bufread);
     let mut ont = Ontology::new();
     let mapping = PrefixMapping::default();
 

--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -21,8 +21,8 @@ use failure::Error;
 ///
 /// The ontology is written in OWL
 /// [XML](https://www.w3.org/TR/owl2-xml-serialization/) syntax.
-pub fn write(
-    write: &mut dyn StdWrite,
+pub fn write<W: StdWrite>(
+    write: W,
     ont: &Ontology,
     mapping: Option<&PrefixMapping>,
 ) -> Result<(), Error> {


### PR DESCRIPTION
This just changes the main OWX writer function to support a generic argument. Current signature requires a `&mut dyn Write` argument, which 1. uses a `dyn` object which has a runtime cost, and 2. cannot take values by ownership. Now you can do the following (while currently you'd need a mutable `f` and pass a mutable reference):
```rust
let f = std::fs::File::create("out.owx").unwrap();
horned_owl::io::owx::writer::write(f, ont, None); 
```

