### PR TITLE
IRI management with `oxiri`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static="1.4.0"
 log = {version="0.4.8"}
 quick-xml={version="0.26.0"}
 indexmap={workspace=true}
+oxiri={workspace=true}
 pretty_rdf={workspace=true}
 rio_api={workspace=true}
 rio_xml={workspace=true}
@@ -34,7 +35,7 @@ indexmap="1.0.2"
 pretty_rdf="0.2.0"
 rio_api="0.7.1"
 rio_xml="0.7.3"
-
+oxiri = "0.2.2"
 [features]
 remote = ["ureq"]
 

--- a/benches/horned.rs
+++ b/benches/horned.rs
@@ -12,8 +12,8 @@ fn a_thousand_classes(bench: &mut Bencher) {
         let b = Build::new_rc();
         let mut o = SetOntology::new();
         for m in 1..1000 {
-            let i = b.iri(format!("http://example.com/b{}", m));
-            let _c = o.declare(b.class(i));
+            let i = b.iri(format!("http://example.com/b{}", m)).unwrap();
+            let _c = o.declare(b.class(i).unwrap());
         }
     })
 }
@@ -28,8 +28,8 @@ fn big_tree(bench: &mut Bencher) {
 }
 
 fn create_tree<A: ForIRI, O: MutableOntology<A>>(b: &Build<A>, o: &mut O, n: &mut i32) {
-    let i = b.iri(format!("http://example.com/a{}", n));
-    let c = b.class(i);
+    let i = b.iri(format!("http://example.com/a{}", n)).unwrap();
+    let c = b.class(i).unwrap();
     create_tree_0(b, o, vec![c], n);
 }
 
@@ -42,11 +42,11 @@ fn create_tree_0<A: ForIRI, O: MutableOntology<A>>(
     let mut next = vec![];
 
     for curr in current.into_iter() {
-        let i = b.iri(format!("http://example.com/a{}", remaining));
-        let c = b.class(i);
+        let i = b.iri(format!("http://example.com/a{}", remaining)).unwrap();
+        let c = b.class(i).unwrap();
         *remaining -= 1;
-        let i = b.iri(format!("http://example.com/a{}", remaining));
-        let d = b.class(i);
+        let i = b.iri(format!("http://example.com/a{}", remaining)).unwrap();
+        let d = b.class(i).unwrap();
         *remaining -= 1;
 
         next.push(c.clone());

--- a/horned-bin/src/bin/horned_big.rs
+++ b/horned-bin/src/bin/horned_big.rs
@@ -42,7 +42,7 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
     let mut o = SetOntology::new_rc();
 
     for i in 1..size + 1 {
-        o.declare(b.class(format!("https://www.example.com/o{}", i)));
+        o.declare(b.class(format!("https://www.example.com/o{}", i))?);
     }
 
     let amo: RcAxiomMappedOntology = o.into();

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -34,7 +34,7 @@ pub fn parse_path(
         }
         Some(ResourceType::RDF) => {
             let b = Build::new();
-            let iri = horned_owl::resolve::path_to_file_iri(&b, path);
+            let iri = horned_owl::resolve::path_to_file_iri(&b, path)?;
             horned_owl::io::rdf::closure_reader::read(&iri, config)?.into()
         }
         None => {
@@ -91,11 +91,11 @@ pub fn materialize_1<'a>(
     // Get all the imports
     for i in import {
         if !done.contains(&i.0) {
-            let local: String = localize_iri(&i.0, &b.iri(input)).into();
+            let local: String = localize_iri(&i.0, &b.iri(input)?)?.into();
             let local_path = Path::new(&local);
             if !local_path.exists() {
                 println!("Retrieving Ontology: {}", &i.0);
-                let imported_data = strict_resolve_iri(&i.0);
+                let imported_data = strict_resolve_iri(&i.0)?;
                 done.push(i.0.clone());
                 println!("Saving to {}", local);
                 let mut file = File::create(&local)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ impl From<usize> for Location{
 impl Display for Location {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BytePosition(u) => write!(f, "Byte Position: {}", u),
+            Self::BytePosition(u) => write!(f, "Byte Position: {u}"),
             Self::Unknown => write!(f, "Unknown")
         }
     }
@@ -64,14 +64,26 @@ impl HornedError {
     }
 }
 
-impl From<quick_xml::Error> for HornedError {
-    fn from(e: quick_xml::Error) -> Self {
+impl From<oxiri::IriParseError> for HornedError {
+    fn from(e: oxiri::IriParseError) -> Self {
         Self::ParserError(e.into(), Location::Unknown)
     }
 }
 
 impl From<rio_xml::RdfXmlError> for HornedError {
     fn from(e: rio_xml::RdfXmlError) -> Self {
+        Self::ParserError(e.into(), Location::Unknown)
+    }
+}
+
+impl From<quick_xml::Error> for HornedError {
+    fn from(e: quick_xml::Error) -> Self {
+        Self::ParserError(e.into(), Location::Unknown)
+    }
+}
+
+impl From<ureq::Error> for HornedError {
+    fn from(e: ureq::Error) -> Self {
         Self::ParserError(e.into(), Location::Unknown)
     }
 }

--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -34,12 +34,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> ClosureOntologyParser<'a, A, AA> {
 
     pub fn parse_path(&mut self, pb: &PathBuf) -> Result<Vec<IRI<A>>, HornedError> {
         let file_iri = path_to_file_iri(self.b, pb);
-        let s = ::std::fs::read_to_string(&pb)?;
+        let s = ::std::fs::read_to_string(pb)?;
         let mut v = vec![];
 
         // We use the IRI that we try to parse, but we don't know that
         // this is the same as file says at this point.
-        self.parse_content_from_iri(s, None, file_iri, &mut v)?;
+        self.parse_content_from_iri(s, None, file_iri?, &mut v)?;
 
         Ok(v)
     }
@@ -75,7 +75,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> ClosureOntologyParser<'a, A, AA> {
         relative_doc_iri: Option<&IRI<A>>,
         v: &mut Vec<IRI<A>>,
     ) -> Result<(), HornedError> {
-        let (new_doc_iri, s) = resolve_iri(source_iri, relative_doc_iri);
+        let (new_doc_iri, s) = resolve_iri(source_iri, relative_doc_iri)?;
         self.parse_content_from_iri(s, relative_doc_iri, new_doc_iri, v)
     }
 
@@ -204,22 +204,24 @@ mod test {
     use std::path::Path;
 
     #[test]
-    fn test_read() {
+    fn test_read() -> Result<(), Box<dyn std::error::Error>> {
         let path = Path::new("src/ont/owl-rdf/import-property.owl");
         let b = Build::new_rc();
-        let iri = path_to_file_iri(&b, &path);
+        let iri = path_to_file_iri(&b, &path)?;
 
         let (_, ic): (RcRDFOntology, _) = read(&iri, Default::default()).unwrap();
         assert!(ic.is_complete());
+
+        Ok(())
     }
 
     // import-property.owl should parse completely with full parse so
     // is a good test.
     #[test]
-    fn test_read_closure() {
+    fn test_read_closure() -> Result<(), Box<dyn std::error::Error>> {
         let path = Path::new("src/ont/owl-rdf/import-property.owl");
         let b = Build::new_rc();
-        let iri = path_to_file_iri(&b, &path);
+        let iri = path_to_file_iri(&b, &path)?;
 
         let v: Vec<(RcRDFOntology, _)> = read_closure(&b, &iri, Default::default()).unwrap();
         let v: Vec<SetOntology<_>> = v
@@ -231,5 +233,7 @@ mod test {
             .collect();
 
         assert_eq!(v.len(), 2);
+
+        Ok(())
     }
 }

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -98,19 +98,19 @@ impl<A: ForIRI> NodeGenerator<A> {
 
 impl<A: ForIRI> From<&IRI<A>> for PTerm<A> {
     fn from(iri: &IRI<A>) -> Self {
-        PNamedNode::new(iri.underlying()).into()
+        PNamedNode::new(String::from(iri).into()).into()
     }
 }
 
 impl<A: ForIRI> From<&IRI<A>> for PNamedNode<A> {
     fn from(iri: &IRI<A>) -> Self {
-        PNamedNode::new(iri.underlying())
+        PNamedNode::new(String::from(iri).into())
     }
 }
 
 impl<A: ForIRI> From<&IRI<A>> for PSubject<A> {
     fn from(iri: &IRI<A>) -> Self {
-        let nn = PNamedNode::new(iri.underlying());
+        let nn = PNamedNode::new(String::from(iri).into());
         nn.into()
     }
 }
@@ -502,7 +502,7 @@ render! {
 render! {
     AnnotationAssertion, self, f, ng, PTriple,
     {
-        let nbn:PSubject<A> = (&self.subject).render(f, ng)?;
+        let nbn:PSubject<A> = (self.subject).render(f, ng)?;
         ng.keep_this_bn(nbn);
 
         self.ann.render(f, ng)
@@ -1080,7 +1080,7 @@ fn obj_cardinality<A: ForIRI, W: Write>(
     let bn = ng.bn();
     let node_ope: PTerm<_> = ope.render(f, ng)?.into();
     let node_n = PTerm::Literal(PLiteral::Typed {
-        value: format!("{}", n).into(),
+        value: format!("{n}").into(),
         datatype: ng.nn(XSD::NonNegativeInteger),
     });
 
@@ -1129,7 +1129,7 @@ fn data_cardinality<A: ForIRI, W: Write>(
     let bn = ng.bn();
     let node_dp: PTerm<_> = (&dp.0).into();
     let node_n = PTerm::Literal(PLiteral::Typed {
-        value: format!("{}", n).into(),
+        value: format!("{n}").into(),
         datatype: ng.nn(XSD::NonNegativeInteger),
     });
     let node_dr: PTerm<_> = dr.render(f, ng)?.into();
@@ -1432,7 +1432,7 @@ render! {
                 // expression.
                 //
                 // It makes little sense to me.
-                let s:PSubject<_> = (&self.sup).render(f, ng)?;
+                let s:PSubject<_> = (self.sup).render(f, ng)?;
                 let o = render_vec_subject(v, f, ng)?;
                 Ok(
                     triple!{
@@ -1442,7 +1442,7 @@ render! {
             }
             SubObjectPropertyExpression::ObjectPropertyExpression(e) =>{
                 let s:PSubject<_> = e.render(f, ng)?;
-                let o:PTerm<_> = (&self.sup).render(f, ng)?.into();
+                let o:PTerm<_> = (self.sup).render(f, ng)?.into();
                 Ok(
                     triple!{
                         f, s, ng.nn(RDFS::SubPropertyOf), o
@@ -1553,11 +1553,11 @@ mod test {
     }
 
     #[test]
-    fn test_ont_rt() {
+    fn test_ont_rt() -> Result<(), Box<dyn std::error::Error>> {
         let mut ont = AxiomMappedOntology::new_rc();
         let build = Build::new();
 
-        let iri = build.iri("http://www.example.com/a".to_string());
+        let iri = build.iri("http://www.example.com/a".to_string())?;
         ont.mut_id().iri = Some(iri);
         let temp_file = Temp::new_file().unwrap();
         let file = File::create(&temp_file).ok().unwrap();
@@ -1567,6 +1567,8 @@ mod test {
         let ont2 = read_ok(&mut BufReader::new(file));
 
         assert_eq!(ont.id().iri, ont2.id().iri);
+
+        Ok(())
     }
 
     fn roundtrip(ont: &str) -> (SetOntology<RcStr>, SetOntology<RcStr>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //#[macro_use]
 extern crate indexmap;
 extern crate log;
+extern crate oxiri;
 extern crate quick_xml;
 
 pub mod collection;

--- a/src/ontology/indexed.rs
+++ b/src/ontology/indexed.rs
@@ -309,11 +309,11 @@ impl<
     }
 
     pub fn i(&self) -> &I {
-        (&self.0).i()
+        (self.0).i()
     }
 
     pub fn j(&self) -> &J {
-        (&self.0).j().i()
+        (self.0).j().i()
     }
 
     pub fn k(&self) -> &K {
@@ -420,11 +420,11 @@ impl<
     }
 
     pub fn i(&self) -> &I {
-        (&self.0).i()
+        (self.0).i()
     }
 
     pub fn j(&self) -> &J {
-        (&self.0).j().i()
+        (self.0).j().i()
     }
 
     pub fn k(&self) -> &K {
@@ -503,9 +503,9 @@ mod test {
         AnnotatedAxiom<RcStr>,
     ) {
         let b = Build::new_rc();
-        let c: NamedEntity<_> = b.class("http://www.example.com/c").into();
-        let o: NamedEntity<_> = b.object_property("http://www.example.com/p").into();
-        let b: NamedEntity<_> = b.data_property("http://www.example.com/d").into();
+        let c: NamedEntity<_> = b.class("http://www.example.com/c").unwrap().into();
+        let o: NamedEntity<_> = b.object_property("http://www.example.com/p").unwrap().into();
+        let b: NamedEntity<_> = b.data_property("http://www.example.com/d").unwrap().into();
 
         (c.into(), o.into(), b.into())
     }

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -262,9 +262,9 @@ impl<A: ForIRI, AA: ForIndex<A>> MutableOntology<A> for IRIMappedOntology<A, AA>
     }
 }
 
-impl<A: ForIRI, AA: ForIndex<A>> IRIMappedOntology<A, AA> {
-    pub fn default() -> IRIMappedOntology<A, AA> {
-        IRIMappedOntology(FourIndexedOntology::new(
+impl<A: ForIRI, AA: ForIndex<A>> Default for IRIMappedOntology<A, AA> {
+    fn default() -> Self {
+        Self(FourIndexedOntology::new(
             SetIndex::new(),
             IRIMappedIndex::new(),
             AxiomMappedIndex::new(),
@@ -272,18 +272,22 @@ impl<A: ForIRI, AA: ForIndex<A>> IRIMappedOntology<A, AA> {
             Default::default(),
         ))
     }
+}
 
-    //Utility method gets an iterator over the axioms in the index for a given IRI
+impl<A: ForIRI, AA: ForIndex<A>> IRIMappedOntology<A, AA> {
+
+
+    // Utility method gets an iterator over the axioms in the index for a given IRI
     pub fn axiom_for_iri(&mut self, iri: &IRI<A>) -> impl Iterator<Item = &AnnotatedAxiom<A>> {
         self.0.j().axiom_for_iri(iri)
     }
 
-    //Utility method gets an iterator over the axioms in the index for a given IRI
+    // Utility method gets an iterator over the axioms in the index for a given IRI
     pub fn axiom_for_kind(&mut self, axkind: AxiomKind) -> impl Iterator<Item = &AnnotatedAxiom<A>> {
         self.0.k().axiom_for_kind(axkind)
     }
 
-    //Utility method updates an axiom in the index
+    // Utility method updates an axiom in the index
     pub fn update_axiom(&mut self, ax: &AnnotatedAxiom<A>, new_ax: AnnotatedAxiom<A>) -> bool {
         self.take(ax);
         self.insert(new_ax)
@@ -351,20 +355,20 @@ mod test {
     }
 
     #[test]
-    fn test_ontology_into_iter() {
+    fn test_ontology_into_iter() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new();
         let mut o = IRIMappedOntology::new_rc();
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
         let disj1 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#a")),
-            ClassExpression::Class(build.class("http://www.example.com#b")),
+            ClassExpression::Class(build.class("http://www.example.com#a")?),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
         ]);
         let disj2 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#b")),
-            ClassExpression::Class(build.class("http://www.example.com#c")),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
+            ClassExpression::Class(build.class("http://www.example.com#c")?),
         ]);
         o.insert(disj1.clone());
         o.insert(disj2.clone());
@@ -386,6 +390,8 @@ mod test {
                 AnnotatedAxiom::from(Axiom::DisjointClasses(disj2)),
             ]
         );
+
+        Ok(())
     }
 
     #[test]
@@ -398,20 +404,20 @@ mod test {
     }
 
     #[test]
-    fn test_ontology_iter() {
+    fn test_ontology_iter() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new();
         let mut o = IRIMappedOntology::new_rc();
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
         let disj1 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#a")),
-            ClassExpression::Class(build.class("http://www.example.com#b")),
+            ClassExpression::Class(build.class("http://www.example.com#a")?),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
         ]);
         let disj2 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#b")),
-            ClassExpression::Class(build.class("http://www.example.com#c")),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
+            ClassExpression::Class(build.class("http://www.example.com#c")?),
         ]);
         o.insert(disj1.clone());
         o.insert(disj2.clone());
@@ -433,5 +439,7 @@ mod test {
                 &AnnotatedAxiom::from(Axiom::DisjointClasses(disj2)),
             ]
         );
+
+        Ok(())
     }
 }

--- a/src/ontology/logically_equal.rs
+++ b/src/ontology/logically_equal.rs
@@ -119,13 +119,13 @@ mod test {
     }
 
     #[test]
-    fn equal_retrieve() {
+    fn equal_retrieve() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new_rc();
         let mut o = LogicallyEqualIndex::new();
-        let decl1: AnnotatedAxiom<_> = DeclareClass(build.class("http://www.example.com#a")).into();
-        let decl2: AnnotatedAxiom<_> = DeclareClass(build.class("http://www.example.com#b")).into();
-        let decl3: AnnotatedAxiom<_> = DeclareClass(build.class("http://www.example.com#c")).into();
+        let decl1: AnnotatedAxiom<_> = DeclareClass(build.class("http://www.example.com#a")?).into();
+        let decl2: AnnotatedAxiom<_> = DeclareClass(build.class("http://www.example.com#b")?).into();
+        let decl3: AnnotatedAxiom<_> = DeclareClass(build.class("http://www.example.com#c")?).into();
 
         o.index_insert(Rc::new(decl1.clone()));
         o.index_insert(Rc::new(decl2.clone()));
@@ -134,10 +134,12 @@ mod test {
         assert!(o.logical_contains(&decl1));
         assert!(o.logical_contains(&decl2));
         assert!(o.logical_contains(&decl3));
+
+        Ok(())
     }
 
     #[test]
-    fn annotation_not_equal_retrieve() {
+    fn annotation_not_equal_retrieve() -> Result<(), Box<dyn std::error::Error>>  {
         // Setup
         let b = Build::new_rc();
         let mut o = TwoIndexedOntology::new(
@@ -147,13 +149,13 @@ mod test {
         );
 
         let ann = Annotation {
-            ap: b.annotation_property("http://www.example.com/ap"),
-            av: b.iri("http://www.example.com/av").into(),
+            ap: b.annotation_property("http://www.example.com/ap")?,
+            av: b.iri("http://www.example.com/av")?.into(),
         };
 
-        let decl1: AnnotatedAxiom<_> = DeclareClass(b.class("http://www.example.com#a")).into();
-        let decl2: AnnotatedAxiom<_> = DeclareClass(b.class("http://www.example.com#b")).into();
-        let decl3: AnnotatedAxiom<_> = DeclareClass(b.class("http://www.example.com#c")).into();
+        let decl1: AnnotatedAxiom<_> = DeclareClass(b.class("http://www.example.com#a")?).into();
+        let decl2: AnnotatedAxiom<_> = DeclareClass(b.class("http://www.example.com#b")?).into();
+        let decl3: AnnotatedAxiom<_> = DeclareClass(b.class("http://www.example.com#c")?).into();
 
         let mut decl1_a = decl1.clone();
         decl1_a.ann.insert(ann.clone());
@@ -172,10 +174,12 @@ mod test {
         assert!(o.j().logical_contains(&decl1));
         assert!(o.j().logical_contains(&decl2));
         assert!(o.j().logical_contains(&decl3));
+
+        Ok(())
     }
 
     #[test]
-    fn test_update_equal_axiom() {
+    fn test_update_equal_axiom() -> Result<(), Box<dyn std::error::Error>> {
         let b = Build::new_rc();
         {
             let mut o = TwoIndexedOntology::new(
@@ -183,22 +187,22 @@ mod test {
                 LogicallyEqualIndex::new(),
                 OntologyID::default(),
             );
-            let ne: NamedEntity<_> = b.class("http://www.example.com").into();
+            let ne: NamedEntity<_> = b.class("http://www.example.com")?.into();
             let ax: Axiom<_> = ne.into();
             let mut dec: AnnotatedAxiom<_> = ax.into();
 
             dec.ann.insert(Annotation {
-                ap: b.annotation_property("http://www.example.com/p1"),
-                av: b.iri("http://www.example.com/a1").into(),
+                ap: b.annotation_property("http://www.example.com/p1")?,
+                av: b.iri("http://www.example.com/a1")?.into(),
             });
 
-            let ne: NamedEntity<_> = b.class("http://www.example.com").into();
+            let ne: NamedEntity<_> = b.class("http://www.example.com")?.into();
             let ax: Axiom<_> = ne.into();
             let mut dec2: AnnotatedAxiom<_> = ax.into();
 
             dec2.ann.insert(Annotation {
-                ap: b.annotation_property("http://www.example.com/p1"),
-                av: b.iri("http://www.example.com/a2").into(),
+                ap: b.annotation_property("http://www.example.com/p1")?,
+                av: b.iri("http://www.example.com/a2")?.into(),
             });
 
             o.insert(dec);
@@ -212,20 +216,20 @@ mod test {
                 LogicallyEqualIndex::new(),
                 OntologyID::default(),
             );
-            let ne: NamedEntity<_> = b.class("http://www.example.com").into();
+            let ne: NamedEntity<_> = b.class("http://www.example.com")?.into();
             let ax: Axiom<_> = ne.into();
             let mut dec: AnnotatedAxiom<_> = ax.into();
             dec.ann.insert(Annotation {
-                ap: b.annotation_property("http://www.example.com/p1"),
-                av: b.iri("http://www.example.com/a1").into(),
+                ap: b.annotation_property("http://www.example.com/p1")?,
+                av: b.iri("http://www.example.com/a1")?.into(),
             });
 
-            let ne: NamedEntity<_> = b.class("http://www.example.com").into();
+            let ne: NamedEntity<_> = b.class("http://www.example.com")?.into();
             let ax: Axiom<_> = ne.into();
             let mut dec2: AnnotatedAxiom<_> = ax.into();
             dec2.ann.insert(Annotation {
-                ap: b.annotation_property("http://www.example.com/p1"),
-                av: b.iri("http://www.example.com/a2").into(),
+                ap: b.annotation_property("http://www.example.com/p1")?,
+                av: b.iri("http://www.example.com/a2")?.into(),
             });
 
             o.insert(dec);
@@ -236,5 +240,7 @@ mod test {
 
             assert_eq!(aa.ann.len(), 2);
         }
+
+        Ok(())
     }
 }

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -118,10 +118,13 @@ impl<A: ForIRI> MutableOntology<A> for SetOntology<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// # use horned_owl::ontology::set::SetOntology;
+    /// # fn doctest_set_insert() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut o = SetOntology::new();
     /// let b = Build::new_rc();
-    /// o.insert(DeclareClass(b.class("http://www.example.com/a")));
-    /// o.insert(DeclareObjectProperty(b.object_property("http://www.example.com/r")));
+    /// o.insert(DeclareClass(b.class("http://www.example.com/a")?));
+    /// o.insert(DeclareObjectProperty(b.object_property("http://www.example.com/r")?));
+    /// # return Ok(());
+    /// # };
     /// ```
     ///
     /// See `declare` for an easier way to declare named entities.
@@ -237,35 +240,39 @@ mod test {
     }
 
     #[test]
-    fn test_ontology_id() {
+    fn test_ontology_id() -> Result<(), Box<dyn std::error::Error>> {
         let mut so = SetOntology::new_rc();
         let b = Build::new_rc();
         let mut oid = OntologyID {
-            iri: Some(b.iri("http://www.example.com/iri")),
-            viri: Some(b.iri("http://www.example.com/viri")),
+            iri: Some(b.iri("http://www.example.com/iri")?),
+            viri: Some(b.iri("http://www.example.com/viri")?),
         };
 
         std::mem::swap(so.mut_id(), &mut oid);
 
-        assert_eq!(so.id().iri, Some(b.iri("http://www.example.com/iri")));
-        assert_eq!(so.id().viri, Some(b.iri("http://www.example.com/viri")))
+        assert_eq!(so.id().iri, Some(b.iri("http://www.example.com/iri")?));
+        assert_eq!(so.id().viri, Some(b.iri("http://www.example.com/viri")?));
+
+        Ok(())
     }
 
     #[test]
-    fn test_ontology_clone() {
+    fn test_ontology_clone() -> Result<(), Box<dyn std::error::Error>> {
         let mut so = SetOntology::new_rc();
         let b = Build::new_rc();
         let mut oid = OntologyID {
-            iri: Some(b.iri("http://www.example.com/iri")),
-            viri: Some(b.iri("http://www.example.com/viri")),
+            iri: Some(b.iri("http://www.example.com/iri")?),
+            viri: Some(b.iri("http://www.example.com/viri")?),
         };
 
         std::mem::swap(so.mut_id(), &mut oid);
 
         let cso = so.clone();
 
-        assert_eq!(cso.id().iri, Some(b.iri("http://www.example.com/iri")));
-        assert_eq!(cso.id().viri, Some(b.iri("http://www.example.com/viri")))
+        assert_eq!(cso.id().iri, Some(b.iri("http://www.example.com/iri")?));
+        assert_eq!(cso.id().viri, Some(b.iri("http://www.example.com/viri")?));
+
+        Ok(())
     }
 
     #[test]
@@ -277,20 +284,20 @@ mod test {
     }
 
     #[test]
-    fn test_ontology_into_iter() {
+    fn test_ontology_into_iter() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new_rc();
         let mut o = SetOntology::new();
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
         let disj1 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#a")),
-            ClassExpression::Class(build.class("http://www.example.com#b")),
+            ClassExpression::Class(build.class("http://www.example.com#a")?),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
         ]);
         let disj2 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#b")),
-            ClassExpression::Class(build.class("http://www.example.com#c")),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
+            ClassExpression::Class(build.class("http://www.example.com#c")?),
         ]);
         o.insert(disj1.clone());
         o.insert(disj2.clone());
@@ -324,6 +331,8 @@ mod test {
         );
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
+
+        Ok(())
     }
 
     #[test]
@@ -336,20 +345,20 @@ mod test {
     }
 
     #[test]
-    fn test_ontology_iter() {
+    fn test_ontology_iter() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new_rc();
         let mut o = SetOntology::new();
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
         let disj1 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#a")),
-            ClassExpression::Class(build.class("http://www.example.com#b")),
+            ClassExpression::Class(build.class("http://www.example.com#a")?),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
         ]);
         let disj2 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#b")),
-            ClassExpression::Class(build.class("http://www.example.com#c")),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
+            ClassExpression::Class(build.class("http://www.example.com#c")?),
         ]);
         o.insert(disj1.clone());
         o.insert(disj2.clone());
@@ -383,16 +392,18 @@ mod test {
         );
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
+
+        Ok(())
     }
 
     #[test]
-    fn test_ontology_into() {
+    fn test_ontology_into() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new_rc();
         let mut o = SetOntology::new();
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
 
         o.insert(decl1.clone());
         o.insert(decl2.clone());
@@ -418,6 +429,8 @@ mod test {
         );
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
+
+        Ok(())
     }
 
     #[test]
@@ -435,20 +448,20 @@ mod test {
     }
 
     #[test]
-    fn test_index_into_iter() {
+    fn test_index_into_iter() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new_rc();
         let mut o = OneIndexedOntology::new(SetIndex::new_rc());
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
         let disj1 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#a")),
-            ClassExpression::Class(build.class("http://www.example.com#b")),
+            ClassExpression::Class(build.class("http://www.example.com#a")?),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
         ]);
         let disj2 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#b")),
-            ClassExpression::Class(build.class("http://www.example.com#c")),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
+            ClassExpression::Class(build.class("http://www.example.com#c")?),
         ]);
         o.insert(disj1.clone());
         o.insert(disj2.clone());
@@ -482,6 +495,8 @@ mod test {
         );
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
+
+        Ok(())
     }
 
     #[test]
@@ -494,20 +509,20 @@ mod test {
     }
 
     #[test]
-    fn test_index_iter() {
+    fn test_index_iter() -> Result<(), Box<dyn std::error::Error>> {
         // Setup
         let build = Build::new_rc();
         let mut o = OneIndexedOntology::new(SetIndex::new_rc());
-        let decl1 = DeclareClass(build.class("http://www.example.com#a"));
-        let decl2 = DeclareClass(build.class("http://www.example.com#b"));
-        let decl3 = DeclareClass(build.class("http://www.example.com#c"));
+        let decl1 = DeclareClass(build.class("http://www.example.com#a")?);
+        let decl2 = DeclareClass(build.class("http://www.example.com#b")?);
+        let decl3 = DeclareClass(build.class("http://www.example.com#c")?);
         let disj1 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#a")),
-            ClassExpression::Class(build.class("http://www.example.com#b")),
+            ClassExpression::Class(build.class("http://www.example.com#a")?),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
         ]);
         let disj2 = DisjointClasses(vec![
-            ClassExpression::Class(build.class("http://www.example.com#b")),
-            ClassExpression::Class(build.class("http://www.example.com#c")),
+            ClassExpression::Class(build.class("http://www.example.com#b")?),
+            ClassExpression::Class(build.class("http://www.example.com#c")?),
         ]);
         o.insert(disj1.clone());
         o.insert(disj2.clone());
@@ -541,5 +556,7 @@ mod test {
         );
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
+
+        Ok(())
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,4 +1,4 @@
-use crate::model::{Build, ForIRI, IRI};
+use crate::{model::{Build, ForIRI, IRI}, error::{HornedError, Location}};
 
 use std::path::{Path, PathBuf};
 
@@ -17,15 +17,22 @@ use ureq;
 /// ```
 /// # use horned_owl::model::*;
 /// # use horned_owl::resolve::*;
+/// # fn doctest_file_iri_to_pathbuf() -> Result<(), Box<dyn std::error::Error>> {
 /// let b = Build::new_rc();
 
-/// let doc_iri = b.iri("file://blah/and.owl");
+/// let doc_iri = b.iri("file://blah/and.owl")?;
 
-/// let path_buf = file_iri_to_pathbuf(&doc_iri);
+/// let path_buf = file_iri_to_pathbuf(&doc_iri)?;
 /// assert_eq!(path_buf.to_str().unwrap(), "blah/and.owl");
+/// # return Ok(());
+/// # };
 /// ```
-pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
-    Path::new(&*iri.split_at(7).1).into()
+pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> Result<PathBuf, HornedError> {
+    if is_file_iri(iri) {
+        Ok(Path::new(&iri.split_at(7).1).into())
+    } else {
+        Err(HornedError::ValidityError(format!("Expected IRI with file scheme, found {}", &iri.scheme()), Location::Unknown))
+    }
 }
 
 /// Return an `IRI` for the given `PathBuf`
@@ -35,16 +42,24 @@ pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
 /// # use horned_owl::model::*;
 /// # use horned_owl::resolve::*;
 /// # use std::path::Path;
+/// # fn doctest_path_to_file_iri() -> Result<(), Box<dyn std::error::Error>> {
 /// let b = Build::new_rc();
 
-/// let target_iri = b.iri("file://blah/and.owl");
+/// let target_iri = b.iri("file://blah/and.owl")?;
 
 /// let path = Path::new("blah/and.owl");
-/// let source_iri = path_to_file_iri(&b, &path);
+/// let source_iri = path_to_file_iri(&b, &path)?;
 /// assert_eq!(source_iri.as_ref(), "file://blah/and.owl");
+/// # return Ok(());
+/// # };
 /// ```
-pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
-    b.iri(format!("file://{}", pb.to_str().unwrap()))
+pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> Result<IRI<A>, HornedError> {
+    if let Some(path_str) = pb.to_str() {
+        b.iri(format!("file://{path_str}"))
+    } else {
+        Err(HornedError::ValidityError(format!("Expected valid Unicode, found: {pb:?}"), Location::Unknown))
+    }
+    
 }
 
 /// Return true if the iri is a file IRI.
@@ -53,14 +68,18 @@ pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
 /// ```
 /// # use horned_owl::model::*;
 /// # use horned_owl::resolve::*;
+/// # fn doctest_is_file_iri() -> Result<(), Box<dyn std::error::Error>> {
 /// let b = Build::new_rc();
 
-/// let doc_iri = b.iri("file://blah/and.owl");
+/// let doc_iri = b.iri("file://local_path/and.owl")?;
 
-/// assert!(is_file_iri(&doc_iri))
+/// assert!(is_file_iri(&doc_iri));
+/// # return Ok(());
+/// # };
 /// ```
 pub fn is_file_iri<A: ForIRI>(iri: &IRI<A>) -> bool {
-    (*iri).starts_with("file:/")
+    iri.scheme() == "file"
+    // (*iri).starts_with("file://")
 }
 
 /// Assuming that doc_iri is a local file IRI, return a new IRI for
@@ -70,63 +89,93 @@ pub fn is_file_iri<A: ForIRI>(iri: &IRI<A>) -> bool {
 /// ```
 /// # use horned_owl::model::*;
 /// # use horned_owl::resolve::*;
+/// # fn doctest_localize_iri() -> Result<(), Box<dyn std::error::Error>> {
 /// let b = Build::new_rc();
 
-/// let doc_iri = b.iri("file://blah/and.owl");
-/// let iri = b.iri("http://www.example.com/or.owl");
+/// let doc_iri = b.iri("file://blah/and.owl")?;
+/// let iri = b.iri("http://www.example.com/or.owl")?;
 
-/// let local = b.iri("file://blah/or.owl");
+/// let local = b.iri("file://blah/or.owl")?;
 
-/// assert_eq!(localize_iri(&iri, &doc_iri), local);
+/// assert_eq!(localize_iri(&iri, &doc_iri)?, local);
+/// # return Ok(());
+/// # };
 /// ```
-pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &IRI<A>) -> IRI<A> {
-    let b = Build::new();
-    let (_, term_iri) = iri.split_at(iri.rfind('/').unwrap() + 1);
-
-    b.iri(if let Some(index) = doc_iri.rfind('/') {
+/// 
+/// # Errors
+/// 
+/// The method fails if `doc_iri` is not an IRI corresponding to a local file.
+pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &IRI<A>) -> Result<IRI<A>, HornedError> {
+    if is_file_iri(doc_iri) {
+        let b = Build::new();
+        // let iri_path = iri.path();
+        // let iri_fragment = if let Some(frag) = iri.fragment() {
+        //     format!("#{}", frag)
+        // } else {
+        //     String::with_capacity(0)
+        // };
+        // let term_iri = A::from(format!("{}{}",iri_path,iri_fragment));
+        let iri_path_begin = iri.as_ref().rfind('/').unwrap() + 1;
+        let (_, term_iri) = iri.as_ref().split_at(iri_path_begin);
+        //
+        b.iri(if let Some(index) = doc_iri.rfind('/') {
         format!("{}/{}", doc_iri.split_at(index).0, term_iri)
+        } else {
+            format!("./{term_iri}")
+        })
+        // doc_iri.resolve(&term_iri)
+            // .map(|result| IRI::from(result))
+            // .map_err(|err| err.into())
     } else {
-        format!("./{}", term_iri)
-    })
+        Err(HornedError::ValidityError(format!("Expected IRI with file scheme, found {}", doc_iri.scheme()), Location::Unknown))
+    }
 }
 
 // Return the ontology as Vec<u8> from `iri` unless we think that it
 // is local to doc_iri
-pub fn resolve_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: Option<&IRI<A>>) -> (IRI<A>, String) {
+pub fn resolve_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: Option<&IRI<A>>) -> Result<(IRI<A>, String), HornedError> {
     let local = if let Some(doc_iri) = doc_iri {
-        localize_iri(iri, doc_iri)
+        localize_iri(iri, doc_iri)?
     } else {
         iri.clone()
     };
 
+    dbg!(&local);
+
     if is_file_iri(&local) {
-        let mut path = file_iri_to_pathbuf(&local);
-        if path.as_path().exists() {
-            return (local, ::std::fs::read_to_string(path).unwrap());
+        let mut path = file_iri_to_pathbuf(&local)?;
+        if path.try_exists()? {
+            return Ok((local, ::std::fs::read_to_string(path)?));
+        } else if let Some(doc_iri) = doc_iri {
+                let (_, doc_ext) = doc_iri.split_once('.').unwrap();
+                path.set_extension(doc_ext);
+                if path.try_exists()? {
+                    return Ok((local, ::std::fs::read_to_string(path)?));
+                }
+        } else {
+            todo!("resolve_iri doesn't have error handling");
         }
+    } 
+    // else {
+    //     Err(HornedError::ValidityError(format!("Expected IRI with file scheme, found {}", local.into_inner().scheme()), Location::Unknown))
+    // }
 
-        if let Some(doc_iri) = doc_iri {
-            let doc_ext = doc_iri.split_once('.').unwrap();
-            path.set_extension(doc_ext.1);
-            if path.exists() {
-                return (local, ::std::fs::read_to_string(path).unwrap());
-            }
-        }
-        todo!("resolve_iri doesn't have error handlign");
-    }
-
-    (local, strict_resolve_iri(iri))
+    Ok((local, strict_resolve_iri(iri)?))
 }
 
 // Return the ontology as Vec<u8> from `iri`.
 #[cfg(feature = "remote")]
-pub fn strict_resolve_iri<A: ForIRI>(iri: &IRI<A>) -> String {
-    let s: String = iri.into();
-    ureq::get(&s).call().unwrap().into_string().unwrap()
+/// Downloads the document pointed by the IRI as a [String].
+pub fn strict_resolve_iri<A: ForIRI>(iri: &IRI<A>) -> Result<String, crate::error::HornedError> {
+    ureq::get(iri)
+        .call()?
+        .into_string()
+        // .map(|res| A::from(res))
+        .map_err(crate::error::HornedError::IOError)
 }
 
 #[cfg(not(feature = "remote"))]
-pub fn strict_resolve_iri<A: ForIRI>(_iri: &IRI<A>) -> String {
+pub fn strict_resolve_iri<A: ForIRI>(_iri: &IRI<A>) -> Result<String, crate::error::HornedError> {
     todo!("fail")
 }
 
@@ -136,35 +185,41 @@ mod test {
     use crate::model::Build;
 
     #[test]
-    fn localize() {
+    fn localize() -> Result<(), Box<dyn std::error::Error>> {
         let b = Build::new_rc();
 
-        let doc_iri = b.iri("file://blah/and.owl");
+        let doc_iri = b.iri("file://blah/and.owl")?;
 
-        let iri = b.iri("http://www.example.com/or.owl");
+        let iri = b.iri("http://www.example.com/or.owl")?;
 
-        let local = b.iri("file://blah/or.owl");
+        let local = b.iri("file://blah/or.owl")?;
 
-        assert_eq!(localize_iri(&iri, &doc_iri), local);
+        assert_eq!(localize_iri(&iri, &doc_iri)?, local);
+
+        Ok(())
     }
 
     #[test]
-    fn simple_iri() {
+    fn simple_iri() -> Result<(), Box<dyn std::error::Error>> {
         let _dir_path_buf = PathBuf::from(file!());
         let b = Build::new_rc();
-        let i: IRI<_> = b.iri("http://www.example.com");
+        let i: IRI<_> = b.iri("http://www.example.com")?;
 
-        strict_resolve_iri(&i);
+        strict_resolve_iri(&i)?;
+
+        Ok(())
     }
 
     #[test]
-    fn test_resolve_iri() {
+    fn test_resolve_iri() -> Result<(), Box<dyn std::error::Error>> {
         let b = Build::new_rc();
-        let i: IRI<_> = b.iri("http://www.example.com/bikepath.md");
-        let doc_iri = b.iri("file://cargo.toml");
+        let i: IRI<_> = b.iri("http://www.example.com/bikepath.md")?;
+        let doc_iri = b.iri("file://cargo.toml")?;
 
-        let bikepath_str = ::std::fs::read_to_string("bikepath.md").unwrap();
-        let (_, iri_str) = resolve_iri(&i, Some(&doc_iri));
+        let bikepath_str = ::std::fs::read_to_string("bikepath.md")?;
+        let (_, iri_str) = resolve_iri(&i, Some(&doc_iri))?;
         assert_eq!(bikepath_str, iri_str);
+
+        Ok(())
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -741,7 +741,7 @@ pub mod entity {
 
     impl<A: ForIRI> Visit<A> for EntityExtract<A> {
         fn visit_iri(&mut self, iri: &IRI<A>) {
-            self.0.push(iri.underlying())
+            self.0.push(String::from(iri).into())
         }
 
         fn visit_anonymous_individual(&mut self, anon: &AnonymousIndividual<A>) {


### PR DESCRIPTION
Addresses #56.
A lot of refactoring involved.
Many methods do now return Results, and fail if the parsed IRI is ill-formed. Tested with make pre-commit and pre-push (except for the ignored test, which is for the moment failing). Passed with cargo clippy a couple of times, there is still some rough spot.