### PR TITLE
Create an ontology interface

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -446,7 +446,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
             )),
             b,
             config,
-            
+
             triple,
             simple: d!(),
             bnode: d!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@
 //! implementation of the OWL2 DL specification. It appears to be
 //! highly performant, being between 1 and 2 orders of magnitude
 //! faster than the OWL API for some tasks.
+#![feature(generic_associated_types)]
+
 //extern crate curie;
 //extern crate enum_meta;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1676,6 +1676,14 @@ pub trait Ontology<A> {
     fn mut_doc_iri(&mut self) -> &mut Option<IRI<A>>;
 }
 
+pub trait IterableOntology<A>: IntoIterator {
+    type Iterator<'collection>: Iterator<Item = &'collection AnnotatedAxiom<A>>
+    where
+        Self: 'collection, A:'collection;
+
+    fn iter<'c>(&'c self) -> Self::Iterator<'c>;
+}
+
 /// Add or remove axioms to an `MutableOntology`
 pub trait MutableOntology<A> {
     /// Insert an axiom into the ontology.

--- a/src/ontology/axiom_mapped.rs
+++ b/src/ontology/axiom_mapped.rs
@@ -302,6 +302,15 @@ impl<A: ForIRI, AA: ForIndex<A>> Ontology<A> for AxiomMappedOntology<A, AA> {
     }
 }
 
+impl<A: ForIRI, AA: ForIndex<A>> IterableOntology<A> for AxiomMappedOntology<A, AA> {
+    type Iterator<'c> = AxiomMappedIter<'c, A, AA>
+        where A:'c, AA:'c;
+
+    fn iter<'c>(&'c self) -> AxiomMappedIter<'c, A, AA>{
+        self.0.i().iter()
+    }
+}
+
 impl<A: ForIRI, AA: ForIndex<A>> MutableOntology<A> for AxiomMappedOntology<A, AA> {
     fn insert<IAA>(&mut self, ax: IAA) -> bool
     where

--- a/src/ontology/indexed.rs
+++ b/src/ontology/indexed.rs
@@ -70,6 +70,7 @@ impl<A: ForIRI, T: ?Sized> ForIndex<A> for T where
 /// do, or the it will be dropped entirely. The `SetIndex` is a simple
 /// way to achieving this.
 pub trait OntologyIndex<A: ForIRI, AA: ForIndex<A>> {
+
     /// Potentially insert an AnnotatedAxiom to the index.
     ///
     /// If the index did not have this value present, true is returned.
@@ -179,6 +180,7 @@ impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>> Ontology<A>
     fn mut_doc_iri(&mut self) -> &mut Option<IRI<A>> {
         &mut self.2
     }
+
 }
 
 impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>> MutableOntology<A>

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -50,11 +50,6 @@ impl<A: ForIRI> SetOntology<A> {
     pub fn from_index<AA: ForIndex<A>>(oid: OntologyID<A>, si: SetIndex<A, AA>) -> SetOntology<A> {
         (oid, si.into_iter().map(|s| s.unwrap())).into()
     }
-
-    /// Gets an iterator that visits the annotated axioms of the ontology.
-    pub fn iter(&self) -> SetIter<'_, A> {
-        SetIter(self.0.i().0.iter())
-    }
 }
 
 impl<A: ForIRI> Ontology<A> for SetOntology<A> {
@@ -72,6 +67,16 @@ impl<A: ForIRI> Ontology<A> for SetOntology<A> {
 
     fn mut_doc_iri(&mut self) -> &mut Option<IRI<A>> {
         self.0.mut_doc_iri()
+    }
+}
+
+impl<A: ForIRI> IterableOntology<A> for SetOntology<A> {
+    type Iterator<'c> = SetIter<'c, A>
+        where A:'c;
+
+    /// Gets an iterator that visits the annotated axioms of the ontology.
+    fn iter<'c>(&'c self) -> SetIter<'c, A> {
+        SetIter(self.0.i().0.iter())
     }
 }
 


### PR DESCRIPTION
Currently, horned does not have an interface for an ontology. WIth the addition of GATs to stable rust, we should be able to add this now. 

This branch/PR is early attempts to get this working and for discussion. Not ready for merging!