### PR TITLE
Manually implement `Default` to avoid introducing a bound on IRI types

### DIFF
--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -54,7 +54,7 @@ macro_rules! onimpl {
     };
 }
 
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ComponentMappedIndex<A, AA> {
     component: RefCell<BTreeMap<ComponentKind, BTreeSet<AA>>>,
     pd: PhantomData<A>,
@@ -210,6 +210,15 @@ onimpl! {AnnotationAssertion, annotation_assertion}
 onimpl! {SubAnnotationPropertyOf, sub_annotation_property_of}
 onimpl! {AnnotationPropertyDomain, annotation_property_domain}
 onimpl! {AnnotationPropertyRange, annotation_property_range}
+
+impl<A, AA> Default for ComponentMappedIndex<A, AA> {
+    fn default() -> Self {
+        Self {
+            component: Default::default(),
+            pd: Default::default(),
+        }
+    }
+}
 
 /// An owning iterator over the annotated components of an `Ontology`.
 impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedIndex<A, AA> {

--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::collections::HashMap;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DeclarationMappedIndex<A, AA>(HashMap<IRI<A>, NamedEntityKind>,
                                          HashSet<IRI<A>>,
                                          PhantomData<AA>);
@@ -84,9 +84,15 @@ macro_rules! some {
     };
 }
 
+impl<A, AA> Default for DeclarationMappedIndex<A, AA> {
+    fn default() -> Self {
+        DeclarationMappedIndex(Default::default(), Default::default(), Default::default())
+    }
+}
+
 impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for DeclarationMappedIndex<A, AA> {
     fn index_insert(&mut self, ax: AA) -> bool {
-        some! {
+        some!{
             {
                 let ne = self.aa_to_ne(ax.borrow())?;
                 let iri = self.aa_to_iri(ax.borrow())?;

--- a/src/ontology/indexed.rs
+++ b/src/ontology/indexed.rs
@@ -110,18 +110,8 @@ impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for NullIndex {
 
 /// A `OneIndexedOntology` operates as a simple adaptor between any
 /// `OntologyIndex` and an `Ontology`.
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct OneIndexedOntology<A, AA, I>(I, Option<IRI<A>>, PhantomData<AA>);
-
-impl<A: ForIRI, AA: ForIndex<A>, I: Clone> Clone for OneIndexedOntology<A, AA, I> {
-    fn clone(&self) -> Self {
-        OneIndexedOntology(
-            self.0.clone(),
-            self.1.clone(),
-            Default::default(),
-        )
-    }
-}
 
 impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>> OneIndexedOntology<A, AA, I> {
     pub fn new(i: I) -> Self {
@@ -159,6 +149,22 @@ where
     }
 }
 
+impl<A, AA, I: Default> Default for OneIndexedOntology<A, AA, I> {
+    fn default() -> Self {
+        OneIndexedOntology(Default::default(), Default::default(), Default::default())
+    }
+}
+
+impl<A: ForIRI, AA: ForIndex<A>, I: Clone> Clone for OneIndexedOntology<A, AA, I> {
+    fn clone(&self) -> Self {
+        OneIndexedOntology(
+            self.0.clone(),
+            self.1.clone(),
+            Default::default(),
+        )
+    }
+}
+
 impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>> Ontology<A>
     for OneIndexedOntology<A, AA, I>{
 }
@@ -179,13 +185,8 @@ impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>> MutableOntology<A>
 /// A `TwoIndexOntology` implements `Ontology` and supports two
 /// `OntologyIndex`. It itself implements `OntologyIndex` so that it
 /// can be composed.
-#[derive(Default, Debug, Eq, PartialEq)]
-pub struct TwoIndexedOntology<
-    A: ForIRI,
-    AA: ForIndex<A>,
-    I: OntologyIndex<A, AA>,
-    J: OntologyIndex<A, AA>,
->(I, J, Option<IRI<A>>, PhantomData<AA>);
+#[derive(Debug, Eq, PartialEq)]
+pub struct TwoIndexedOntology<A, AA, I, J>(I, J, Option<IRI<A>>, PhantomData<AA>);
 
 impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>, J: OntologyIndex<A, AA>>
     TwoIndexedOntology<A, AA, I, J>
@@ -204,6 +205,12 @@ impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>, J: OntologyIndex<A, AA
 
     pub fn index(self) -> (I, J) {
         (self.0, self.1)
+    }
+}
+
+impl<A, AA, I: Default, J: Default> Default for TwoIndexedOntology<A, AA, I, J> {
+    fn default() -> Self {
+        TwoIndexedOntology(Default::default(), Default::default(), Default::default(), Default::default())
     }
 }
 
@@ -241,14 +248,8 @@ impl<A: ForIRI, AA: ForIndex<A>, I: OntologyIndex<A, AA>, J: OntologyIndex<A, AA
 }
 
 /// ThreeIndexedOntology supports three indexes.
-#[derive(Default, Debug)]
-pub struct ThreeIndexedOntology<
-    A: ForIRI,
-    AA: ForIndex<A>,
-    I: OntologyIndex<A, AA>,
-    J: OntologyIndex<A, AA>,
-    K: OntologyIndex<A, AA>,
->(TwoIndexedOntology<A, AA, I, TwoIndexedOntology<A, AA, J, K>>);
+#[derive(Debug)]
+pub struct ThreeIndexedOntology<A, AA, I, J, K>(TwoIndexedOntology<A, AA, I, TwoIndexedOntology<A, AA, J, K>>);
 
 impl<
         A: ForIRI,
@@ -287,6 +288,12 @@ impl<
     pub fn index(self) -> (I, J, K) {
         let index = (self.0).1.index();
         ((self.0).0, index.0, index.1)
+    }
+}
+
+impl<A, AA, I: Default, J: Default, K: Default> Default for ThreeIndexedOntology<A, AA, I, J, K> {
+    fn default() -> Self {
+        ThreeIndexedOntology(Default::default())
     }
 }
 
@@ -339,15 +346,8 @@ impl<
 }
 
 /// FourIndexedOntology supports three indexes.
-#[derive(Default, Debug)]
-pub struct FourIndexedOntology<
-    A: ForIRI,
-    AA: ForIndex<A>,
-    I: OntologyIndex<A, AA>,
-    J: OntologyIndex<A, AA>,
-    K: OntologyIndex<A, AA>,
-    L: OntologyIndex<A, AA>,
->(TwoIndexedOntology<A, AA, I, ThreeIndexedOntology<A, AA, J, K, L>>);
+#[derive(Debug)]
+pub struct FourIndexedOntology<A, AA, I, J, K, L>(TwoIndexedOntology<A, AA, I, ThreeIndexedOntology<A, AA, J, K, L>>);
 
 impl<
         A: ForIRI,
@@ -386,6 +386,13 @@ impl<
     pub fn index(self) -> (I, J, K, L) {
         let index = (self.0).1.index();
         ((self.0).0, index.0, index.1, index.2)
+    }
+}
+
+impl<A, AA, I: Default, J: Default, K: Default, L: Default> Default for FourIndexedOntology<A, AA, I, J, K, L>
+{
+    fn default() -> Self {
+        FourIndexedOntology(Default::default())
     }
 }
 

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -25,7 +25,7 @@ use super::set::SetIndex;
 
 use std::collections::HashSet;
 
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct IRIMappedIndex<A, AA> {
     irindex: RefCell<BTreeMap<IRI<A>, BTreeSet<AA>>>,
 }
@@ -96,6 +96,14 @@ impl<A: ForIRI, AA: ForIndex<A>> IRIMappedIndex<A, AA> {
     ///
     pub fn component(&self, iri: &IRI<A>) -> impl Iterator<Item = &Component<A>> {
         self.component_for_iri(iri).map(|ann| &ann.component)
+    }
+}
+
+impl<A, AA> Default for IRIMappedIndex<A, AA> {
+    fn default() -> Self {
+        Self {
+            irindex: Default::default(),
+        }
     }
 }
 

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -1,5 +1,5 @@
 //! Rapid, simple, in-memory `Ontology` and `OntologyIndex`
-use std::{collections::HashSet, iter::FromIterator, rc::Rc};
+use std::{hash::Hash, collections::HashSet, iter::FromIterator, rc::Rc};
 
 use super::indexed::ForIndex;
 use super::indexed::{OneIndexedOntology, OntologyIndex};
@@ -175,8 +175,8 @@ where
 /// An `OntologyIndex` implemented over an in-memory HashSet. When
 /// combined with an `IndexedOntology` this should be nearly as
 /// fastest as `SetOntology`.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct SetIndex<A: ForIRI, AA: ForIndex<A>>(HashSet<AA>, PhantomData<A>);
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetIndex<A, AA: Hash + Eq>(HashSet<AA>, PhantomData<A>);
 
 impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for SetIndex<A, AA> {
     fn index_insert(&mut self, cmp: AA) -> bool {
@@ -185,6 +185,12 @@ impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for SetIndex<A, AA> {
 
     fn index_remove(&mut self, cmp: &AnnotatedComponent<A>) -> bool {
         self.0.remove(cmp)
+    }
+}
+
+impl<A, AA: Hash + Eq> Default for SetIndex<A, AA> {
+    fn default() -> Self {
+        SetIndex(Default::default(), Default::default())
     }
 }
 


### PR DESCRIPTION
Hi!

While refactoring the parsers to be included in the crate, I realized that I can make them generic over the ontology types, provided they are `Default + MutableOntology`, because in both cases I create an empty ontology and then fill it incrementally with `MutableOntology::insert`.

I tried doing that but then got plenty of errors, because most ontology types implement `Default` with a trait requirement on the IRI generic type, which should not be needed, but is caused by the use of the `derive` implementation. Since for all ontology types creating a default one means initializing an empty collection, there shouldn't be a need for default IRI anywhere.

To address this I manually implemented `Default` on all index and ontology types. I also changed the type signatures of the index types to be more consistent: `OneIndexedOntology` didn't have any type boundary in the type signature while the remaining indexed ontology had one. I removed the type boundaries where they were not needed, otherwise it created a whole kind of trait dependency issues in the trait implementations.

In general I've observed that library interfaces have much more flexibility when the type boundaries are as lax as possible, and there are many places here where `ForIRI` is required where it would actually not be needed (for instance in `Clone` implementations). This would be nice to standardize :smile: