### PR TITLE
Adds missing handling of DataUnionOf in RDF and OWX readers.

### DIFF
--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -1025,6 +1025,11 @@ from_start! {
                         till_end(r, b"DataIntersectionOf")?
                     )
                 }
+                b"DataUnionOf" => {
+                    DataRange::DataUnionOf(
+                        till_end(r, b"DataUnionOf")?
+                    )
+                }
                 b"DataComplementOf" => {
                     DataRange::DataComplementOf(
                         Box::new(from_next(r)?)

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -763,6 +763,15 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
                         )
                     }
                 }
+                [[_, Term::OWL(VOWL::UnionOf), Term::BNode(bnodeid)],//: rustfmt hard line!
+                [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
+                {
+                   ok_some! {
+                       DataRange::DataUnionOf(
+                           self.fetch_dr_seq(bnodeid)?
+                       )
+                   }
+                }
                 [[_, Term::OWL(VOWL::DatatypeComplementOf), term],//:
                  [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
                 {
@@ -2330,11 +2339,6 @@ mod test {
     }
 
     #[test]
-    fn datatype() {
-        compare("datatype");
-    }
-
-    #[test]
     fn object_has_value() {
         compare("object-has-value");
     }
@@ -2367,6 +2371,11 @@ mod test {
     #[test]
     fn object_exact_cardinality() {
         compare("object-exact-cardinality");
+    }
+
+    #[test]
+    fn datatype() {
+        compare("datatype");
     }
 
     #[test]


### PR DESCRIPTION
Addresses #69.

The related tests in `io::owx::reader` could be improved, the reason the mishandling could not be detected is that the test `io::owx::reader::test::datatype_union()` only checks that one type definition appears in the ontology, no matter what its kind is. The test `io::rdf::reader::test::datatype_union()` seems also not to be informative, as it would in this case just compare the two faulty files.

The writers seemed to already handle this construct properly.