### PR TITLE
Improving error handling for IRI resolution

### DIFF
--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -104,7 +104,7 @@ pub fn materialize_1<'a>(
             let local_path = Path::new(&local);
             if !local_path.exists() {
                 println!("Retrieving Ontology: {}", &i.0);
-                let imported_data = strict_resolve_iri(&i.0);
+                let imported_data = strict_resolve_iri(&i.0)?;
                 done.push(i.0.clone());
                 println!("Saving to {}", local);
                 let mut file = File::create(&local)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,3 +107,9 @@ impl<R: RuleType + 'static> From<pest::error::Error<R>> for HornedError {
         Self::ParserError(e.into(), location)
     }
 }
+
+impl From<ureq::Error> for HornedError {
+    fn from(e: ureq::Error) -> Self {
+        Self::ParserError(e.into(), Location::Unknown)
+    }
+}

--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -76,7 +76,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> ClosureOntologyParser<'a, A, AA> {
         relative_doc_iri: Option<&IRI<A>>,
         v: &mut Vec<IRI<A>>,
     ) -> Result<(), HornedError> {
-        let (new_doc_iri, s) = resolve_iri(source_iri, relative_doc_iri);
+        let (new_doc_iri, s) = resolve_iri(source_iri, relative_doc_iri)?;
         self.parse_content_from_iri(s, relative_doc_iri, new_doc_iri, v)
     }
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -452,7 +452,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
     }
 
     pub fn from_doc_iri(b: &'a Build<A>, iri: &IRI<A>, config: ParserConfiguration) -> OntologyParser<'a, A, AA> {
-        OntologyParser::from_bufread(b, &mut Cursor::new(strict_resolve_iri(iri)), config)
+        OntologyParser::from_bufread(b, &mut Cursor::new(strict_resolve_iri(iri).expect("the IRI should resolve successfully")), config)
     }
 
     fn group_triples(

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -19,14 +19,14 @@ use ureq;
 /// # use horned_owl::resolve::*;
 /// let b = Build::new_rc();
 
-/// let doc_iri = b.iri("file://blah/and.owl");
+/// let doc_iri = b.iri("file://base_dir/and.owl");
 
 /// let path_buf = file_iri_to_pathbuf(&doc_iri);
-/// assert_eq!(path_buf.to_str().unwrap(), "blah/and.owl");
+/// assert_eq!(path_buf.to_str().unwrap(), "base_dir/and.owl");
 /// ```
 #[deprecated(since="1.0.0", note="please use `as_local_path_buffer` instead")]
 pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
-    Path::new(&*iri.split_at(7).1).into()
+    Path::new(iri.split_at(7).1).into()
 }
 
 /// Return an `IRI` for the given `PathBuf`
@@ -38,11 +38,11 @@ pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
 /// # use std::path::Path;
 /// let b = Build::new_rc();
 
-/// let target_iri = b.iri("file://blah/and.owl");
+/// let target_iri = b.iri("file://base_dir/and.owl");
 
-/// let path = Path::new("blah/and.owl");
+/// let path = Path::new("base_dir/and.owl");
 /// let source_iri = path_to_file_iri(&b, &path);
-/// assert_eq!(source_iri.as_ref(), "file://blah/and.owl");
+/// assert_eq!(source_iri.as_ref(), "file://base_dir/and.owl");
 /// ```
 pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
     pb.to_str()
@@ -58,11 +58,11 @@ pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
 /// # use horned_owl::resolve::*;
 /// let b = Build::new_rc();
 
-/// let doc_iri = b.iri("file://blah/and.owl");
+/// let doc_iri = b.iri("file://base_dir/and.owl");
 /// let path_buf = as_local_path_buffer(&doc_iri);
 
 /// assert!(path_buf.is_some());
-/// assert_eq!(path_buf.unwrap().to_str().unwrap(), "blah/and.owl");
+/// assert_eq!(path_buf.unwrap().to_str().unwrap(), "base_dir/and.owl");
 /// ```
 pub fn as_local_path_buffer<A: ForIRI>(iri: &IRI<A>) -> Option<PathBuf> {
     iri.strip_prefix("file://")
@@ -78,10 +78,10 @@ pub fn as_local_path_buffer<A: ForIRI>(iri: &IRI<A>) -> Option<PathBuf> {
 /// # use horned_owl::resolve::*;
 /// let b = Build::new_rc();
 
-/// let doc_iri = b.iri("file://blah/and.owl");
+/// let doc_iri = b.iri("file://base_dir/and.owl");
 /// let iri = b.iri("http://www.example.com/or.owl");
 
-/// let local = b.iri("file://blah/or.owl");
+/// let local = b.iri("file://base_dir/or.owl");
 
 /// assert_eq!(localize_iri(&iri, &doc_iri), local);
 /// ```
@@ -182,7 +182,6 @@ pub fn strict_resolve_iri<A: ForIRI>(_iri: &IRI<A>) -> String {
 
 #[cfg(test)]
 mod test {
-    use std::rc::Rc;
 
     use super::*;
     use crate::model::Build;
@@ -191,11 +190,11 @@ mod test {
     fn localize() {
         let b = Build::new_rc();
 
-        let doc_iri = b.iri("file://blah/and.owl");
+        let doc_iri = b.iri("file://base_dir/and.owl");
 
         let iri = b.iri("http://www.example.com/or.owl");
 
-        let local = b.iri("file://blah/or.owl");
+        let local = b.iri("file://base_dir/or.owl");
 
         assert_eq!(localize_iri(&iri, &doc_iri), local);
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -24,6 +24,7 @@ use ureq;
 /// let path_buf = file_iri_to_pathbuf(&doc_iri);
 /// assert_eq!(path_buf.to_str().unwrap(), "blah/and.owl");
 /// ```
+// #[deprecated]
 pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
     Path::new(&*iri.split_at(7).1).into()
 }
@@ -44,10 +45,12 @@ pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
 /// assert_eq!(source_iri.as_ref(), "file://blah/and.owl");
 /// ```
 pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
-    b.iri(format!("file://{}", pb.to_str().unwrap()))
+    pb.to_str()
+    .map(|path_str| b.iri(format!("file://{path_str}")))
+    .expect("path should contain valid Unicode")
 }
 
-/// Return true if the iri is a file IRI.
+/// Returns `Some(path_buf)` if the input corresponds to a file IRI.
 ///
 /// # Examples
 /// ```
@@ -56,11 +59,14 @@ pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
 /// let b = Build::new_rc();
 
 /// let doc_iri = b.iri("file://blah/and.owl");
+/// let path_buf = as_local_path_buffer(&doc_iri);
 
-/// assert!(is_file_iri(&doc_iri))
+/// assert!(path_buf.is_some());
+/// assert_eq!(path_buf.unwrap().to_str().unwrap(), "blah/and.owl");
 /// ```
-pub fn is_file_iri<A: ForIRI>(iri: &IRI<A>) -> bool {
-    (*iri).starts_with("file:/")
+pub fn as_local_path_buffer<A: ForIRI>(iri: &IRI<A>) -> Option<PathBuf> {
+    iri.strip_prefix("file://")
+        .map(|path_str| Path::new(path_str).into())
 }
 
 /// Assuming that doc_iri is a local file IRI, return a new IRI for
@@ -90,40 +96,84 @@ pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &IRI<A>) -> IRI<A> {
     })
 }
 
-// Return the ontology as Vec<u8> from `iri` unless we think that it
+// Return the ontology as a string from `iri` unless we think that it
 // is local to doc_iri
-pub fn resolve_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: Option<&IRI<A>>) -> (IRI<A>, String) {
+pub fn resolve_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: Option<&IRI<A>>) -> Result<(IRI<A>, String), HornedError> {
     let local = if let Some(doc_iri) = doc_iri {
         localize_iri(iri, doc_iri)
     } else {
         iri.clone()
     };
 
-    if is_file_iri(&local) {
-        let mut path = file_iri_to_pathbuf(&local);
-        if path.as_path().exists() {
-            return (local, ::std::fs::read_to_string(path).unwrap());
-        }
+    if let Some(mut path) = as_local_path_buffer(&local) {
+        
+        let file_exists = path.try_exists()?;
+        
+        if file_exists {
+            let result = ::std::fs::read_to_string(path)?;
+            Ok((local, result))
+        } else if let Some(doc_iri) = doc_iri {
+            let doc_ext = doc_iri.split_once('.')
+                .map(|(_, ext)| ext)
+                .unwrap_or("");
+            path.set_extension(doc_ext);
 
-        if let Some(doc_iri) = doc_iri {
-            let doc_ext = doc_iri.split_once('.').unwrap();
-            path.set_extension(doc_ext.1);
-            if path.exists() {
-                return (local, ::std::fs::read_to_string(path).unwrap());
+            let doc_file_exists = path.try_exists()?;
+            if doc_file_exists {
+                let result = ::std::fs::read_to_string(path)?;
+                Ok((local, result))
+            } else {
+                Err(HornedError::IOError(std::io::Error::from(std::io::ErrorKind::NotFound)))
             }
+        } else {
+            Err(HornedError::IOError(std::io::Error::from(std::io::ErrorKind::NotFound)))
         }
-        todo!("resolve_iri doesn't have error handling: {:?} {:?}", iri, doc_iri);
+    } else {
+        Ok((local, strict_resolve_iri(iri).unwrap()))
     }
+    // if is_file_iri(&local) {
+    //     let mut path = file_iri_to_pathbuf(&local);
+    //     if path.as_path().exists() {
+    //         return Ok((local, ::std::fs::read_to_string(path).unwrap()));
+    //     }
 
-    (local, strict_resolve_iri(iri))
+    //     if let Some(doc_iri) = doc_iri {
+    //         let doc_ext = doc_iri.split_once('.').unwrap();
+    //         path.set_extension(doc_ext.1);
+    //         if path.exists() {
+    //             return Ok((local, ::std::fs::read_to_string(path).unwrap()));
+    //         }
+    //     }
+    //     todo!("resolve_iri doesn't have error handling: {:?} {:?}", iri, doc_iri);
+    // }
 }
 
 // Return the ontology as Vec<u8> from `iri`.
 #[cfg(feature = "remote")]
-pub fn strict_resolve_iri<A: ForIRI>(iri: &IRI<A>) -> String {
-    let s: String = iri.into();
-    ureq::get(&s).call().unwrap().into_string().unwrap()
+use crate::error::HornedError;
+pub fn strict_resolve_iri<A: ForIRI>(iri: &IRI<A>) -> Result<String, HornedError> {
+    // let s: String = iri.into();
+    ureq::get(iri).call()?
+        .into_string()
+        .map_err(|e| e.into())
 }
+
+// pub fn resolve_iri_as_bytes<A: ForIRI>(iri: &IRI<A>) -> Result<Vec<u8>, HornedError> {
+//     // let s: String = iri.into();
+//     let response = ureq::get(iri).call()?;
+//     let len: Option<usize> = response.header("Content-Length").map(|len| len.parse().unwrap());
+
+//     let mut bytes: Vec<u8> = if let Some(cap) = len {
+//         Vec::with_capacity(cap)
+//     } else {
+//         Vec::new()
+//     };
+    
+//     response.into_reader()
+//         .read_to_end(&mut bytes)?;
+
+//     Ok(bytes)
+// }
 
 #[cfg(not(feature = "remote"))]
 pub fn strict_resolve_iri<A: ForIRI>(_iri: &IRI<A>) -> String {
@@ -132,6 +182,8 @@ pub fn strict_resolve_iri<A: ForIRI>(_iri: &IRI<A>) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::rc::Rc;
+
     use super::*;
     use crate::model::Build;
 
@@ -154,7 +206,7 @@ mod test {
         let b = Build::new_rc();
         let i: IRI<_> = b.iri("http://www.example.com");
 
-        strict_resolve_iri(&i);
+        assert!(strict_resolve_iri(&i).is_ok());
     }
 
     #[test]
@@ -164,7 +216,7 @@ mod test {
         let doc_iri = b.iri("file://cargo.toml");
 
         let bikepath_str = ::std::fs::read_to_string("bikepath.md").unwrap();
-        let (_, iri_str) = resolve_iri(&i, Some(&doc_iri));
+        let (_, iri_str) = resolve_iri(&i, Some(&doc_iri)).unwrap();
         assert_eq!(bikepath_str, iri_str);
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -24,7 +24,7 @@ use ureq;
 /// let path_buf = file_iri_to_pathbuf(&doc_iri);
 /// assert_eq!(path_buf.to_str().unwrap(), "blah/and.owl");
 /// ```
-// #[deprecated]
+#[deprecated(since="1.0.0", note="please use `as_local_path_buffer` instead")]
 pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
     Path::new(&*iri.split_at(7).1).into()
 }


### PR DESCRIPTION
Following a `todo!()` in `resolve`, I tried to implement some basic error handling.

A few methods in the module now return `Option`s or `Result`s with minimal change to external code.

I tried to adhere to the logic of `resolve::resolve_iri()` as much as possible, though I admit I do not understand why it works this way.