### PR TITLE
refactor: using &str directly instead of S: Borrow<str>.

### DIFF
--- a/benches/horned.rs
+++ b/benches/horned.rs
@@ -12,8 +12,8 @@ fn a_thousand_classes(bench: &mut Bencher) {
         let b = Build::new_rc();
         let mut o = SetOntology::new();
         for m in 1..1000 {
-            let i = b.iri(format!("http://example.com/b{}", m));
-            let _c = o.declare(b.class(i));
+            let i = b.iri(&format!("http://example.com/b{}", m));
+            let _c = o.declare(b.class(&i));
         }
     })
 }
@@ -28,8 +28,8 @@ fn big_tree(bench: &mut Bencher) {
 }
 
 fn create_tree<A: ForIRI, O: MutableOntology<A>>(b: &Build<A>, o: &mut O, n: &mut i32) {
-    let i = b.iri(format!("http://example.com/a{}", n));
-    let c = b.class(i);
+    let i = b.iri(&format!("http://example.com/a{}", n));
+    let c = b.class(&i);
     create_tree_0(b, o, vec![c], n);
 }
 
@@ -42,11 +42,11 @@ fn create_tree_0<A: ForIRI, O: MutableOntology<A>>(
     let mut next = vec![];
 
     for curr in current.into_iter() {
-        let i = b.iri(format!("http://example.com/a{}", remaining));
-        let c = b.class(i);
+        let i = b.iri(&format!("http://example.com/a{}", remaining));
+        let c = b.class(&i);
         *remaining -= 1;
-        let i = b.iri(format!("http://example.com/a{}", remaining));
-        let d = b.class(i);
+        let i = b.iri(&format!("http://example.com/a{}", remaining));
+        let d = b.class(&i);
         *remaining -= 1;
 
         next.push(c.clone());
@@ -191,8 +191,8 @@ fn food_to_vec() -> Vec<u8> {
     std::fs::read("./benches/ont/food.owl").unwrap()
 }
 
-fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &Vec<u8>, b: Build<A>) -> RDFOntology<A, AA> {
-    let mut c = Cursor::new(v.clone());
+fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &[u8], b: Build<A>) -> RDFOntology<A, AA> {
+    let mut c = Cursor::new(v);
     horned_owl::io::rdf::reader::read_with_build(&mut c, &b, Default::default())
         .unwrap()
         .0

--- a/horned-bin/src/bin/horned_big.rs
+++ b/horned-bin/src/bin/horned_big.rs
@@ -55,7 +55,7 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
     });
 
     for i in 1..size + 1 {
-        o.declare(b.class(format!("https://www.example.com/o{}", i)));
+        o.declare(b.class(&format!("https://www.example.com/o{}", i)));
     }
 
     let amo: RcComponentMappedOntology = o.into();

--- a/src/io/ofn/reader/from_pair.rs
+++ b/src/io/ofn/reader/from_pair.rs
@@ -605,7 +605,7 @@ macro_rules! impl_ce_data_cardinality {
             Some(pair) => DataRange::from_pair(pair, $ctx)?,
             // No data range is equivalent to `rdfs:Literal` as a data range.
             // see https://www.w3.org/TR/owl2-syntax/#Data_Property_Cardinality_Restrictions
-            None => Datatype($ctx.build.iri(OWL2Datatype::Literal)).into(),
+            None => Datatype($ctx.build.iri(&OWL2Datatype::Literal)).into(),
         };
         Ok(ClassExpression::$dt { n, dp, dr })
     }};
@@ -620,7 +620,7 @@ macro_rules! impl_ce_obj_cardinality {
             Some(x) => Self::from_pair(x, $ctx).map(Box::new)?,
             // Missing class expression is equivalent to `owl:Thing` as class expression.
             // see https://www.w3.org/TR/owl2-syntax/#Object_Property_Cardinality_Restrictions
-            None => Box::new(ClassExpression::Class(Class($ctx.build.iri(OWL::Thing)))),
+            None => Box::new(ClassExpression::Class(Class($ctx.build.iri(&OWL::Thing)))),
         };
         Ok(ClassExpression::$card { n, ope, bce })
     }};
@@ -858,7 +858,7 @@ impl<A: ForIRI> FromPair<A> for IRI<A> {
                     local.as_str(),
                 );
                 match ctx.mapping.expand_curie(&curie) {
-                    Ok(s) => Ok(ctx.build.iri(s)),
+                    Ok(s) => Ok(ctx.build.iri(&s)),
                     Err(curie::ExpansionError::Invalid) => {
                         Err(HornedError::invalid_at("undefined prefix", span))
                     }

--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -218,7 +218,7 @@ fn get_iri_value_for<A: ForIRI, R: BufRead>(
                 // Into an iri
                 r.build.iri(
                     // or a curie
-                    x,
+                    &x,
                 )
             }),
     )
@@ -926,7 +926,7 @@ impl<A: ForIRI> FromStart<A> for AnonymousIndividual<A> {
         e: &BytesStart,
     ) -> Result<AnonymousIndividual<A>, HornedError> {
         let ai: AnonymousIndividual<_> = r.build.anon(
-            get_attr_value_str(&mut r.reader, e, b"nodeID")?
+            &get_attr_value_str(&mut r.reader, e, b"nodeID")?
                 .ok_or_else(|| error_missing_attribute("nodeID Expected", r))?,
         );
         Ok(ai)
@@ -1337,7 +1337,7 @@ from_xml! {IRI, r, end,
                 match e {
                     (ref _ns,Event::Text(ref e)) => {
                         iri = Some(r.build.iri
-                                   (decode_expand_curie_maybe(r, e)?));
+                                   (&decode_expand_curie_maybe(r, e)?));
                     },
                     (ref ns, Event::End(ref e))
                         if is_owl_name(ns, e, end) =>

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -998,7 +998,7 @@ mod test {
         let mut ont = ComponentMappedOntology::new_rc();
         let build = Build::new();
 
-        let iri = build.iri("http://www.example.com/a".to_string());
+        let iri = build.iri("http://www.example.com/a");
         ont.insert(OntologyID {
             iri: Some(iri.clone()),
             viri: None,

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -1211,7 +1211,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
                                 {
                                     n:self.fetch_u32(literal)?,
                                     ope,
-                                    bce: self.b.class(VOWL::Thing).into()
+                                    bce: self.b.class(&VOWL::Thing).into()
                                 }
                             },
                             PropertyExpression::DataProperty(dp) => {
@@ -1219,7 +1219,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
                                 {
                                     n:self.fetch_u32(literal)?,
                                     dp,
-                                    dr: self.b.datatype(OWL2Datatype::Literal).into(),
+                                    dr: self.b.datatype(&OWL2Datatype::Literal).into(),
                                 }
                             }
                             _ => {
@@ -1251,7 +1251,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
                         {
                             n:self.fetch_u32(literal)?,
                             ope: pr.into(),
-                            bce: self.b.class(VOWL::Thing).into()
+                            bce: self.b.class(&VOWL::Thing).into()
                         }
                     }
                 }
@@ -1278,7 +1278,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
                         {
                             n:self.fetch_u32(literal)?,
                             ope: pr.into(),
-                            bce: self.b.class(VOWL::Thing).into()
+                            bce: self.b.class(&VOWL::Thing).into()
                         }
                     }
                 }
@@ -1852,7 +1852,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
                 [Term::Iri(iri), Term::Iri(ap), _]
                     if parse_all
                         || (self.o.0).j().is_annotation_property(ap)
-                        || is_annotation_builtin(ap.as_ref()) =>
+                        || is_annotation_builtin(ap) =>
                 {
                     firi(self, &triple.0, iri)
                 }
@@ -1864,7 +1864,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> OntologyParser<'a, A, AA> {
         for (k, v) in std::mem::take(&mut self.bnode) {
             let fbnode = |s: &mut OntologyParser<_, _>, t, ind: &BNode<A>| {
                 let ann = s.ann_map.remove(t).unwrap_or_default();
-                let ind: AnonymousIndividual<A> = s.b.anon(ind.0.clone());
+                let ind: AnonymousIndividual<A> = s.b.anon(&ind.0);
                 s.merge(AnnotatedComponent {
                     component: AnnotationAssertion {
                         subject: ind.into(),

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -1783,7 +1783,7 @@ mod test {
         let mut ont = ComponentMappedOntology::new_rc();
         let build = Build::new();
 
-        let iri = build.iri("http://www.example.com/a".to_string());
+        let iri = build.iri("http://www.example.com/a");
         ont.insert(OntologyID {
             iri: Some(iri),
             viri: None,
@@ -1841,7 +1841,7 @@ mod test {
     #[test_resources("src/ont/owl-rdf/ambiguous/*.owl")]
     fn roundtrip_rdf(resource: &str) {
         let resource = &slurp::read_all_to_string(resource).unwrap();
-        assert_round(&resource);
+        assert_round(resource);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -256,8 +256,8 @@ impl<A: ForIRI> IRI<A> {
     /// ```
     ///
     /// Use `is` to compare to another IRI
-    pub fn is_as<S: AsRef<str>>(&self, other: S) -> bool {
-        **self == *other.as_ref()
+    pub fn is_as(&self, other: &str) -> bool {
+        **self == *other
     }
 }
 
@@ -290,12 +290,12 @@ impl<A: ForIRI> Build<A> {
     /// let anon = b.anon("anon00001");
     /// assert_eq!("anon00001", String::from(anon));
     /// ```
-    pub fn anon<S: Borrow<str>>(&self, s: S) -> AnonymousIndividual<A> {
+    pub fn anon(&self, s: &str) -> AnonymousIndividual<A> {
         let mut cache = self.1.borrow_mut();
-        if let Some(anon) = cache.get(s.borrow()) {
+        if let Some(anon) = cache.get(s) {
             anon.clone()
         } else {
-            let anon = AnonymousIndividual(s.borrow().to_string().into());
+            let anon = AnonymousIndividual(s.to_string().into());
             cache.insert(anon.clone());
             anon
         }
@@ -311,12 +311,12 @@ impl<A: ForIRI> Build<A> {
     /// let iri = b.iri("http://www.example.com");
     /// assert_eq!("http://www.example.com", String::from(iri));
     /// ```
-    pub fn iri<S: Borrow<str>>(&self, s: S) -> IRI<A> {
+    pub fn iri(&self, s: &str) -> IRI<A> {
         let mut cache = self.0.borrow_mut();
-        if let Some(iri) = cache.get(s.borrow()) {
+        if let Some(iri) = cache.get(s) {
             iri.clone()
         } else {
-            let iri = IRI(s.borrow().to_string().into());
+            let iri = IRI(s.to_string().into());
             cache.insert(iri.clone());
             iri
         }
@@ -330,16 +330,13 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let c1 = b.class("http://www.example.com".to_string());
+    /// let c1 = b.class(&"http://www.example.com".to_string());
     /// let c2 = b.class("http://www.example.com");
     ///
     /// assert_eq!(c1, c2);
     /// ```
     ///
-    pub fn class<S>(&self, s: S) -> Class<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn class(&self, s: &str) -> Class<A> {
         Class(self.iri(s))
     }
 
@@ -350,15 +347,12 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let obp1 = b.object_property("http://www.example.com".to_string());
+    /// let obp1 = b.object_property(&"http://www.example.com".to_string());
     /// let obp2 = b.object_property("http://www.example.com");
     ///
     /// assert_eq!(obp1, obp2);
     /// ```
-    pub fn object_property<S>(&self, s: S) -> ObjectProperty<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn object_property(&self, s: &str) -> ObjectProperty<A> {
         ObjectProperty(self.iri(s))
     }
 
@@ -369,15 +363,12 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let anp1 = b.annotation_property("http://www.example.com".to_string());
+    /// let anp1 = b.annotation_property(&"http://www.example.com".to_string());
     /// let anp2 = b.annotation_property("http://www.example.com");
     ///
     /// assert_eq!(anp1, anp2);
     /// ```
-    pub fn annotation_property<S>(&self, s: S) -> AnnotationProperty<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn annotation_property(&self, s: &str) -> AnnotationProperty<A> {
         AnnotationProperty(self.iri(s))
     }
 
@@ -388,15 +379,12 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let dp1 = b.data_property("http://www.example.com".to_string());
+    /// let dp1 = b.data_property(&"http://www.example.com".to_string());
     /// let dp2 = b.data_property("http://www.example.com");
     ///
     /// assert_eq!(dp1, dp2);
     /// ```
-    pub fn data_property<S>(&self, s: S) -> DataProperty<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn data_property(&self, s: &str) -> DataProperty<A> {
         DataProperty(self.iri(s))
     }
 
@@ -407,15 +395,12 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let ni1 = b.named_individual("http://www.example.com".to_string());
+    /// let ni1 = b.named_individual(&"http://www.example.com".to_string());
     /// let ni2 = b.named_individual("http://www.example.com");
     ///
     /// assert_eq!(ni1, ni2);
     /// ```
-    pub fn named_individual<S>(&self, s: S) -> NamedIndividual<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn named_individual(&self, s: &str) -> NamedIndividual<A> {
         NamedIndividual(self.iri(s))
     }
 
@@ -426,15 +411,12 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let ni1 = b.datatype("http://www.example.com".to_string());
+    /// let ni1 = b.datatype(&"http://www.example.com".to_string());
     /// let ni2 = b.datatype("http://www.example.com");
     ///
     /// assert_eq!(ni1, ni2);
     /// ```
-    pub fn datatype<S>(&self, s: S) -> Datatype<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn datatype(&self, s: &str) -> Datatype<A> {
         Datatype(self.iri(s))
     }
 
@@ -445,15 +427,12 @@ impl<A: ForIRI> Build<A> {
     /// ```
     /// # use horned_owl::model::*;
     /// let b = Build::new_rc();
-    /// let ni1 = b.variable("http://www.example.com".to_string());
+    /// let ni1 = b.variable(&"http://www.example.com".to_string());
     /// let ni2 = b.variable("http://www.example.com");
     ///
     /// assert_eq!(ni1, ni2);
     /// ```
-    pub fn variable<S>(&self, s: S) -> Variable<A>
-    where
-        S: Borrow<str>,
-    {
+    pub fn variable(&self, s: &str) -> Variable<A> {
         Variable(self.iri(s))
     }
 }
@@ -624,8 +603,8 @@ macro_rules! named {
                 /// # use horned_owl::model::Build;
                 /// let build = Build::new_rc();
                 /// let iri = build.iri("http://www.example.com");
-                /// let class = build.class(iri.clone());
-                /// let individual = build.named_individual(iri.clone());
+                /// let class = build.class(&iri);
+                /// let individual = build.named_individual(&iri);
                 ///
                 /// // Named entities can use equality
                 /// assert_eq!(class, class);
@@ -660,7 +639,7 @@ macro_rules! named {
                 /// ```
                 ///
                 /// Use `is` to compare $name to other named entities, or IRIs
-                pub fn is_as<S:AsRef<str>>(&self, other: S) -> bool
+                pub fn is_as(&self, other: &str) -> bool
                 {
                     IRI::<A>::is_as(self, other)
                 }
@@ -2142,9 +2121,9 @@ mod test {
     fn test_iri_creaadtion() {
         let build = Build::new();
 
-        let iri1 = build.iri("http://example.com".to_string());
+        let iri1 = build.iri("http://example.com");
 
-        let iri2 = build.iri("http://example.com".to_string());
+        let iri2 = build.iri("http://example.com");
 
         // these are equal to each other
         assert_eq!(iri1, iri2);
@@ -2160,9 +2139,9 @@ mod test {
     fn test_iri_string_creation() {
         let build = Build::new_rc();
 
-        let iri_string = build.iri("http://www.example.com".to_string());
+        let iri_string = build.iri(&"http://www.example.com".to_string());
         let iri_static = build.iri("http://www.example.com");
-        let iri_from_iri = build.iri(iri_static.clone());
+        let iri_from_iri = build.iri(&iri_static);
 
         let s = "http://www.example.com";
         let iri_str = build.iri(s);
@@ -2210,7 +2189,7 @@ mod test {
     #[test]
     fn test_class_string_ref() {
         let s = String::from("http://www.example.com");
-        let c = Build::new_rc().class(s.clone());
+        let c = Build::new_rc().class(&s);
 
         assert!(c.is_as(&s));
     }
@@ -2232,8 +2211,8 @@ mod test {
         let build = Build::new_rc();
 
         let iri = build.iri("http://www.example.com");
-        let class = build.class(iri.clone());
-        let individual = build.named_individual(iri.clone());
+        let class = build.class(&iri);
+        let individual = build.named_individual(&iri);
 
         // Class comparision with equals
         assert_eq!(class, class);
@@ -2255,7 +2234,7 @@ mod test {
         assert!(!class.is_as("http://www.fred.com"));
 
         // Or other classes if we deref a bit
-        assert!(class.is_as(&*class));
+        assert!(class.is_as(&class));
     }
 
     #[test]
@@ -2311,7 +2290,7 @@ mod test {
 
         let iri = b.iri("http://www.example.com");
         let ca = Atom::ClassAtom {
-            pred: ClassExpression::Class(b.class(iri.clone())),
+            pred: ClassExpression::Class(b.class(&iri)),
             arg: IArgument::Variable(iri.clone().into()),
         };
 

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -52,7 +52,7 @@ impl<A: ForIRI> Reanonymize<A> {
 impl<A: ForIRI> VisitMut<A> for Reanonymize<A> {
     fn visit_anonymous_individual(&mut self, ai: &mut AnonymousIndividual<A>) {
         self.count += 1;
-        std::mem::swap(ai, &mut self.b.anon(format!("anon_{}", self.count)))
+        std::mem::swap(ai, &mut self.b.anon(&format!("anon_{}", self.count)))
     }
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -53,7 +53,7 @@ pub fn file_iri_to_pathbuf<A: ForIRI>(iri: &IRI<A>) -> PathBuf {
 /// ```
 pub fn path_to_file_iri<A: ForIRI>(b: &Build<A>, pb: &Path) -> IRI<A> {
     pb.to_str()
-        .map(|path_str| b.iri(format!("file://{path_str}")))
+        .map(|path_str| b.iri(&format!("file://{path_str}")))
         .expect("path should contain valid Unicode")
 }
 
@@ -96,11 +96,13 @@ pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &IRI<A>) -> IRI<A> {
     let b = Build::new();
     let (_, term_iri) = iri.split_at(iri.rfind('/').unwrap() + 1);
 
-    b.iri(if let Some(index) = doc_iri.rfind('/') {
+    let s = if let Some(index) = doc_iri.rfind('/') {
         format!("{}/{}", doc_iri.split_at(index).0, term_iri)
     } else {
         format!("./{}", term_iri)
-    })
+    };
+
+    b.iri(&s)
 }
 
 /// Return contents of an IRI as a string

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -261,9 +261,9 @@ pub fn to_built_in_entity<A: ForIRI>(iri: &IRI<A>) -> Option<NamedOWLEntityKind>
     }
 }
 
-pub fn entity_for_iri<A: ForIRI, S: Borrow<str>>(
-    type_iri: S,
-    entity_iri: S,
+pub fn entity_for_iri<A: ForIRI>(
+    type_iri: &str,
+    entity_iri: &str,
     b: &Build<A>,
 ) -> Result<NamedOWLEntity<A>, HornedError> {
     // Datatypes are handled here because they are not a
@@ -272,16 +272,13 @@ pub fn entity_for_iri<A: ForIRI, S: Borrow<str>>(
         return Ok(b.datatype(entity_iri).into());
     }
 
-    match &type_iri.borrow().strip_prefix(Namespace::OWL.as_ref()) {
+    match &type_iri.strip_prefix(Namespace::OWL.as_ref()) {
         Some("Class") => Ok(b.class(entity_iri).into()),
         Some("ObjectProperty") => Ok(b.object_property(entity_iri).into()),
         Some("DatatypeProperty") => Ok(b.data_property(entity_iri).into()),
         Some("AnnotationProperty") => Ok(b.annotation_property(entity_iri).into()),
         Some("NamedIndividual") => Ok(b.named_individual(entity_iri).into()),
-        _ => Err(invalid!(
-            "IRI is not a type of entity:{:?}",
-            type_iri.borrow()
-        )),
+        _ => Err(invalid!("IRI is not a type of entity:{:?}", type_iri)),
     }
 }
 
@@ -307,8 +304,8 @@ vocabulary_type! {
 }
 
 #[inline]
-pub fn is_annotation_builtin<A: AsRef<str>>(iri: A) -> bool {
-    AnnotationBuiltIn::from_str(iri.as_ref()).is_ok()
+pub fn is_annotation_builtin(iri: &str) -> bool {
+    AnnotationBuiltIn::from_str(iri).is_ok()
     // AnnotationBuiltIn::all()
     //     .iter()
     //     .any(|item| item.as_ref() == iri.as_ref())
@@ -890,10 +887,10 @@ mod tests {
         ));
         // ...and `String`s.
         assert!(is_annotation_builtin(
-            "http://www.w3.org/2000/01/rdf-schema#comment".to_string()
+            &"http://www.w3.org/2000/01/rdf-schema#comment".to_string()
         ));
         assert!(!is_annotation_builtin(
-            "http://www.w3.org/2002/07/owl#fred".to_string()
+            &"http://www.w3.org/2002/07/owl#fred".to_string()
         ));
     }
 


### PR DESCRIPTION
* numbers of `clone()`s decreased
* number of explicit `borrow()` calls decreased
* we use `&` a bit more often
* all public methods generating named individuals have a simpler signature