### PR TITLE
IRI mapped updates for py-horned-owl performance

### DIFF
--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -15,7 +15,7 @@ use super::set::SetOntology;
 use crate::model::*;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     iter::FromIterator,
     ops::Deref,
     rc::Rc,
@@ -57,37 +57,37 @@ macro_rules! onimpl {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ComponentMappedIndex<A, AA> {
-    component: RefCell<BTreeMap<ComponentKind, BTreeSet<AA>>>,
+pub struct ComponentMappedIndex<A: ForIRI, AA: ForIndex<A>> {
+    component: RefCell<HashMap<ComponentKind, HashSet<AA>>>,
     pd: PhantomData<A>,
 }
 
 impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
     pub fn new() -> ComponentMappedIndex<A, AA> {
         ComponentMappedIndex {
-            component: RefCell::new(BTreeMap::new()),
+            component: RefCell::new(HashMap::new()),
             pd: Default::default(),
         }
     }
 
     /// Fetch the component hashmap as a raw pointer.
     ///
-    /// This method also ensures that the BTreeSet for `cmk` is
+    /// This method also ensures that the HashSet for `cmk` is
     /// instantiated, which means that it effects equality of the
     /// ontology. It should only be used where the intention is to
     /// update the ontology.
-    fn component_as_ptr(&self, cmk: ComponentKind) -> *mut BTreeMap<ComponentKind, BTreeSet<AA>> {
+    fn component_as_ptr(&self, cmk: ComponentKind) -> *mut HashMap<ComponentKind, HashSet<AA>> {
         self.component.borrow_mut().entry(cmk).or_default();
         self.component.as_ptr()
     }
 
     /// Fetch the components for the given kind.
-    fn set_for_kind(&self, cmk: ComponentKind) -> Option<&BTreeSet<AA>> {
+    fn set_for_kind(&self, cmk: ComponentKind) -> Option<&HashSet<AA>> {
         unsafe { (*self.component.as_ptr()).get(&cmk) }
     }
 
     /// Fetch the components for given kind as a mutable ref.
-    fn mut_set_for_kind(&mut self, cmk: ComponentKind) -> &mut BTreeSet<AA> {
+    fn mut_set_for_kind(&mut self, cmk: ComponentKind) -> &mut HashSet<AA> {
         unsafe { (*self.component_as_ptr(cmk)).get_mut(&cmk).unwrap() }
     }
 
@@ -203,7 +203,7 @@ onimpl! {AnnotationPropertyDomain, annotation_property_domain}
 onimpl! {AnnotationPropertyRange, annotation_property_range}
 onimpl! {Rule, rule}
 
-impl<A, AA> Default for ComponentMappedIndex<A, AA> {
+impl<A: ForIRI, AA: ForIndex<A>> Default for ComponentMappedIndex<A, AA> {
     fn default() -> Self {
         Self {
             component: Default::default(),
@@ -217,12 +217,12 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedIndex<A, AA> {
     type Item = AnnotatedComponent<A>;
     type IntoIter = std::vec::IntoIter<AnnotatedComponent<A>>;
     fn into_iter(self) -> Self::IntoIter {
-        let btreemap = self.component.into_inner();
+        let hashmap = self.component.into_inner();
 
         // The collect switches the type which shows up in the API. Blegh.
-        let v: Vec<AnnotatedComponent<A>> = btreemap
+        let v: Vec<AnnotatedComponent<A>> = hashmap
             .into_values()
-            .flat_map(BTreeSet::into_iter)
+            .flat_map(HashSet::into_iter)
             .map(|fi| fi.unwrap())
             .collect();
 
@@ -234,7 +234,7 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedIndex<A, AA> {
 pub struct ComponentMappedIter<'a, A: ForIRI, AA: ForIndex<A>> {
     ont: &'a ComponentMappedIndex<A, AA>,
     kinds: VecDeque<&'a ComponentKind>,
-    inner: Option<<&'a BTreeSet<AA> as IntoIterator>::IntoIter>,
+    inner: Option<<&'a HashSet<AA> as IntoIterator>::IntoIter>,
 }
 
 impl<'a, A: ForIRI, AA: ForIndex<A>> Iterator for ComponentMappedIter<'a, A, AA> {
@@ -249,7 +249,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> Iterator for ComponentMappedIter<'a, A, AA>
         // Attempt to consume the iterator for the next component kind
         if !self.kinds.is_empty() {
             let kind = self.kinds.pop_front().unwrap();
-            self.inner = self.ont.set_for_kind(*kind).map(BTreeSet::iter);
+            self.inner = self.ont.set_for_kind(*kind).map(HashSet::iter);
             self.next()
         } else {
             None
@@ -280,7 +280,7 @@ impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for ComponentMappedIndex<A
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct ComponentMappedOntology<A, AA>(OneIndexedOntology<A, AA, ComponentMappedIndex<A, AA>>);
+pub struct ComponentMappedOntology<A: ForIRI, AA: ForIndex<A>>(OneIndexedOntology<A, AA, ComponentMappedIndex<A, AA>>);
 
 pub type RcComponentMappedOntology = ComponentMappedOntology<RcStr, Rc<AnnotatedComponent<RcStr>>>;
 pub type ArcComponentMappedOntology =

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -15,7 +15,7 @@ use super::set::SetOntology;
 use crate::model::*;
 use std::{
     cell::RefCell,
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     iter::FromIterator,
     ops::Deref,
     rc::Rc,
@@ -57,37 +57,37 @@ macro_rules! onimpl {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ComponentMappedIndex<A: ForIRI, AA: ForIndex<A>> {
-    component: RefCell<HashMap<ComponentKind, HashSet<AA>>>,
+pub struct ComponentMappedIndex<A, AA> {
+    component: RefCell<BTreeMap<ComponentKind, BTreeSet<AA>>>,
     pd: PhantomData<A>,
 }
 
 impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
     pub fn new() -> ComponentMappedIndex<A, AA> {
         ComponentMappedIndex {
-            component: RefCell::new(HashMap::new()),
+            component: RefCell::new(BTreeMap::new()),
             pd: Default::default(),
         }
     }
 
     /// Fetch the component hashmap as a raw pointer.
     ///
-    /// This method also ensures that the HashSet for `cmk` is
+    /// This method also ensures that the BTreeSet for `cmk` is
     /// instantiated, which means that it effects equality of the
     /// ontology. It should only be used where the intention is to
     /// update the ontology.
-    fn component_as_ptr(&self, cmk: ComponentKind) -> *mut HashMap<ComponentKind, HashSet<AA>> {
+    fn component_as_ptr(&self, cmk: ComponentKind) -> *mut BTreeMap<ComponentKind, BTreeSet<AA>> {
         self.component.borrow_mut().entry(cmk).or_default();
         self.component.as_ptr()
     }
 
     /// Fetch the components for the given kind.
-    fn set_for_kind(&self, cmk: ComponentKind) -> Option<&HashSet<AA>> {
+    fn set_for_kind(&self, cmk: ComponentKind) -> Option<&BTreeSet<AA>> {
         unsafe { (*self.component.as_ptr()).get(&cmk) }
     }
 
     /// Fetch the components for given kind as a mutable ref.
-    fn mut_set_for_kind(&mut self, cmk: ComponentKind) -> &mut HashSet<AA> {
+    fn mut_set_for_kind(&mut self, cmk: ComponentKind) -> &mut BTreeSet<AA> {
         unsafe { (*self.component_as_ptr(cmk)).get_mut(&cmk).unwrap() }
     }
 
@@ -203,7 +203,7 @@ onimpl! {AnnotationPropertyDomain, annotation_property_domain}
 onimpl! {AnnotationPropertyRange, annotation_property_range}
 onimpl! {Rule, rule}
 
-impl<A: ForIRI, AA: ForIndex<A>> Default for ComponentMappedIndex<A, AA> {
+impl<A, AA> Default for ComponentMappedIndex<A, AA> {
     fn default() -> Self {
         Self {
             component: Default::default(),
@@ -217,12 +217,12 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedIndex<A, AA> {
     type Item = AnnotatedComponent<A>;
     type IntoIter = std::vec::IntoIter<AnnotatedComponent<A>>;
     fn into_iter(self) -> Self::IntoIter {
-        let hashmap = self.component.into_inner();
+        let btreemap = self.component.into_inner();
 
         // The collect switches the type which shows up in the API. Blegh.
-        let v: Vec<AnnotatedComponent<A>> = hashmap
+        let v: Vec<AnnotatedComponent<A>> = btreemap
             .into_values()
-            .flat_map(HashSet::into_iter)
+            .flat_map(BTreeSet::into_iter)
             .map(|fi| fi.unwrap())
             .collect();
 
@@ -234,7 +234,7 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedIndex<A, AA> {
 pub struct ComponentMappedIter<'a, A: ForIRI, AA: ForIndex<A>> {
     ont: &'a ComponentMappedIndex<A, AA>,
     kinds: VecDeque<&'a ComponentKind>,
-    inner: Option<<&'a HashSet<AA> as IntoIterator>::IntoIter>,
+    inner: Option<<&'a BTreeSet<AA> as IntoIterator>::IntoIter>,
 }
 
 impl<'a, A: ForIRI, AA: ForIndex<A>> Iterator for ComponentMappedIter<'a, A, AA> {
@@ -249,7 +249,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> Iterator for ComponentMappedIter<'a, A, AA>
         // Attempt to consume the iterator for the next component kind
         if !self.kinds.is_empty() {
             let kind = self.kinds.pop_front().unwrap();
-            self.inner = self.ont.set_for_kind(*kind).map(HashSet::iter);
+            self.inner = self.ont.set_for_kind(*kind).map(BTreeSet::iter);
             self.next()
         } else {
             None
@@ -280,7 +280,7 @@ impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for ComponentMappedIndex<A
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct ComponentMappedOntology<A: ForIRI, AA: ForIndex<A>>(OneIndexedOntology<A, AA, ComponentMappedIndex<A, AA>>);
+pub struct ComponentMappedOntology<A, AA>(OneIndexedOntology<A, AA, ComponentMappedIndex<A, AA>>);
 
 pub type RcComponentMappedOntology = ComponentMappedOntology<RcStr, Rc<AnnotatedComponent<RcStr>>>;
 pub type ArcComponentMappedOntology =

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -352,14 +352,17 @@ mod test {
         let mut v: Vec<_> = o.into_iter().collect();
         v.sort();
 
+        // The index contains a copy of a component for each IRI in a component
         assert_eq!(
             v,
             [
                 AnnotatedComponent::from(Component::DeclareClass(decl1)),
                 AnnotatedComponent::from(Component::DeclareClass(decl2)),
                 AnnotatedComponent::from(Component::DeclareClass(decl3)),
-                AnnotatedComponent::from(Component::DisjointClasses(disj1)),
-                AnnotatedComponent::from(Component::DisjointClasses(disj2)),
+                AnnotatedComponent::from(Component::DisjointClasses(disj1.clone())), // Once for #a
+                AnnotatedComponent::from(Component::DisjointClasses(disj1)),         // Once for #b
+                AnnotatedComponent::from(Component::DisjointClasses(disj2.clone())), // Once for #a
+                AnnotatedComponent::from(Component::DisjointClasses(disj2)),         // Once for #b
             ]
         );
     }
@@ -398,15 +401,18 @@ mod test {
         // Iteration order is not guaranteed
         let mut v: Vec<_> = o.iter().collect();
         v.sort();
-
+        
+        // The index contains a copy of a component for each IRI in a component
         assert_eq!(
             v,
             [
                 &AnnotatedComponent::from(Component::DeclareClass(decl1)),
                 &AnnotatedComponent::from(Component::DeclareClass(decl2)),
                 &AnnotatedComponent::from(Component::DeclareClass(decl3)),
-                &AnnotatedComponent::from(Component::DisjointClasses(disj1)),
-                &AnnotatedComponent::from(Component::DisjointClasses(disj2)),
+                &AnnotatedComponent::from(Component::DisjointClasses(disj1.clone())), // Once for #a
+                &AnnotatedComponent::from(Component::DisjointClasses(disj1)),         // Once for #b
+                &AnnotatedComponent::from(Component::DisjointClasses(disj2.clone())), // Once for #a
+                &AnnotatedComponent::from(Component::DisjointClasses(disj2)),         // Once for #b
             ]
         );
     }

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -296,14 +296,6 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for IRIMappedOntology<A, AA> {
     }
 }
 
-// impl<A: ForIRI, AA: ForIndex<A>> From<RDFOntology<A, AA>> for IRIMappedOntology<A, AA> {
-//     fn from(rdfo: RDFOntology<A, AA>) -> Self {
-//         IRIMappedOntology(FourIndexedOntology(
-//             rdfo.
-//         ))
-//     }
-// }
-
 impl<A: ForIRI, AA: ForIndex<A>> From<SetOntology<A>> for IRIMappedOntology<A, AA> {
     fn from(so: SetOntology<A>) -> IRIMappedOntology<A, AA> {
         let mut imo = IRIMappedOntology::default();

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -60,10 +60,6 @@ impl<A: ForIRI> SetOntology<A> {
         self.0.i()
     }
 
-    pub fn index(self) -> SetIndex<A, AnnotatedComponent<A>> {
-        self.0.index()
-    }
-
     /// Gets an iterator that visits the annotated components of the ontology.
     pub fn iter(&self) -> SetIter<'_, A> {
         SetIter(self.0.i().0.iter())

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -60,6 +60,10 @@ impl<A: ForIRI> SetOntology<A> {
         self.0.i()
     }
 
+    pub fn index(self) -> SetIndex<A, AnnotatedComponent<A>> {
+        self.0.index()
+    }
+
     /// Gets an iterator that visits the annotated components of the ontology.
     pub fn iter(&self) -> SetIter<'_, A> {
         SetIter(self.0.i().0.iter())

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -245,6 +245,10 @@ impl<A: ForIRI, AA: ForIndex<A>> SetIndex<A, AA> {
     pub fn the_ontology_id_or_default(&self) -> OntologyID<A> {
         self.the_ontology_id().unwrap_or_default()
     }
+
+    pub fn members(&self) -> impl IntoIterator<Item=AA>  + '_{
+        self.0.iter().map(|c| c.clone())
+    }
 }
 
 impl SetIndex<RcStr, Rc<AnnotatedComponent<RcStr>>> {


### PR DESCRIPTION
To improve the performance of Py-Horned-OWL, the `BTree(Set|Map)` in `Component`- and `IRIMappedIndex` are changed to `Hash(Set|Map)` and the `IRIMappedOntology` now only holds a `IRIMappedIndex`. The other indexes are now dynamically handled on the Py-Horned-OWL site.

Also, the `SetIndex` is extend by a method to expose its members as smart pointer. When we build additional indexes from a `SetIndex`, this allows us to reuse the memory and not clone the components in the new index.

Currently, I'm having problems with the `IntoIter` implementations for the `IRIMappedIndex`. With the current implementation the tests fail as it just lists all components stored in the index and some components occur multiple times. E.g. `DisjointClasses(:A :B)` occurs once for `:A` and once for `:B`.