### PR TITLE
ontology: removes RefCells from indexes.

### DIFF
--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -14,7 +14,6 @@ use super::indexed::ForIndex;
 use super::set::SetOntology;
 use crate::model::*;
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, BTreeSet, VecDeque},
     iter::FromIterator,
     ops::Deref,
@@ -58,37 +57,26 @@ macro_rules! onimpl {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ComponentMappedIndex<A, AA> {
-    component: RefCell<BTreeMap<ComponentKind, BTreeSet<AA>>>,
+    component: BTreeMap<ComponentKind, BTreeSet<AA>>,
     pd: PhantomData<A>,
 }
 
 impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
     pub fn new() -> ComponentMappedIndex<A, AA> {
         ComponentMappedIndex {
-            component: RefCell::new(BTreeMap::new()),
+            component: BTreeMap::new(),
             pd: Default::default(),
         }
     }
 
-    /// Fetch the component hashmap as a raw pointer.
-    ///
-    /// This method also ensures that the BTreeSet for `cmk` is
-    /// instantiated, which means that it effects equality of the
-    /// ontology. It should only be used where the intention is to
-    /// update the ontology.
-    fn component_as_ptr(&self, cmk: ComponentKind) -> *mut BTreeMap<ComponentKind, BTreeSet<AA>> {
-        self.component.borrow_mut().entry(cmk).or_default();
-        self.component.as_ptr()
-    }
-
     /// Fetch the components for the given kind.
     fn set_for_kind(&self, cmk: ComponentKind) -> Option<&BTreeSet<AA>> {
-        unsafe { (*self.component.as_ptr()).get(&cmk) }
+        self.component.get(&cmk)
     }
 
     /// Fetch the components for given kind as a mutable ref.
     fn mut_set_for_kind(&mut self, cmk: ComponentKind) -> &mut BTreeSet<AA> {
-        unsafe { (*self.component_as_ptr(cmk)).get_mut(&cmk).unwrap() }
+        self.component.entry(cmk).or_default()
     }
 
     /// Gets an iterator that visits the annotated components of the ontology.
@@ -97,7 +85,7 @@ impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
         ComponentMappedIter {
             ont: self,
             inner: None,
-            kinds: unsafe { (*self.component.as_ptr()).keys().collect() },
+            kinds: self.component.keys().collect(),
         }
     }
 
@@ -217,10 +205,9 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedIndex<A, AA> {
     type Item = AnnotatedComponent<A>;
     type IntoIter = std::vec::IntoIter<AnnotatedComponent<A>>;
     fn into_iter(self) -> Self::IntoIter {
-        let btreemap = self.component.into_inner();
-
         // The collect switches the type which shows up in the API. Blegh.
-        let v: Vec<AnnotatedComponent<A>> = btreemap
+        let v: Vec<AnnotatedComponent<A>> = self
+            .component
             .into_values()
             .flat_map(BTreeSet::into_iter)
             .map(|fi| fi.unwrap())
@@ -264,7 +251,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> IntoIterator for &'a ComponentMappedIndex<A
         ComponentMappedIter {
             ont: self,
             inner: None,
-            kinds: unsafe { (*self.component.as_ptr()).keys().collect() },
+            kinds: self.component.keys().collect(),
         }
     }
 }
@@ -427,7 +414,6 @@ mod test {
     #[test]
     fn test_ontology_cons() {
         let _ = ComponentMappedOntology::new_rc();
-        assert!(true);
     }
 
     #[test]
@@ -540,7 +526,7 @@ mod test {
         o.insert(decl3.clone());
 
         // Iteration is based on ascending order of axiom kinds.
-        let mut it = (&o).i().iter();
+        let mut it = o.i().iter();
         assert_eq!(
             it.next(),
             Some(&AnnotatedComponent::from(Component::DeclareClass(decl1)))

--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -168,7 +168,6 @@ mod test {
     #[test]
     fn test_cons() {
         let _d = DeclarationMappedIndex::new_rc();
-        assert!(true);
     }
 
     #[test]

--- a/src/ontology/indexed.rs
+++ b/src/ontology/indexed.rs
@@ -452,7 +452,6 @@ mod test {
     #[test]
     fn one_cons() {
         let _o = OneIndexedOntology::new_rc(SetIndex::new());
-        assert!(true);
     }
 
     #[test]
@@ -488,10 +487,8 @@ mod test {
     #[test]
     fn two_cons() {
         let _o = TwoIndexedOntology::new(SetIndex::new_rc(), SetIndex::new());
-        assert!(true);
 
         let _o = TwoIndexedOntology::new(SetIndex::new_rc(), NullIndex::default());
-        assert!(true);
     }
 
     #[test]

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -12,7 +12,6 @@ use crate::{
     visitor::immutable::{entity::IRIExtract, Walk},
 };
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, BTreeSet},
     rc::Rc,
     sync::Arc,
@@ -27,14 +26,14 @@ use std::collections::HashSet;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct IRIMappedIndex<A, AA> {
-    irindex: RefCell<BTreeMap<IRI<A>, BTreeSet<AA>>>,
+    irindex: BTreeMap<IRI<A>, BTreeSet<AA>>,
 }
 
 impl<A: ForIRI, AA: ForIndex<A>> IRIMappedIndex<A, AA> {
     /// Create a new ontology.
     pub fn new() -> IRIMappedIndex<A, AA> {
         IRIMappedIndex {
-            irindex: RefCell::new(BTreeMap::new()),
+            irindex: BTreeMap::new(),
         }
     }
 
@@ -45,25 +44,14 @@ impl<A: ForIRI, AA: ForIndex<A>> IRIMappedIndex<A, AA> {
         w.into_visit().into_vec().into_iter().collect()
     }
 
-    /// Fetch the iris hashmap as a raw pointer.
-    ///
-    /// This method also ensures that the BTreeSet for `iri` is
-    /// instantiated, which means that it effects equality of the
-    /// ontology. It should only be used where the intention is to
-    /// update the ontology.
-    fn components_as_ptr(&self, iri: &IRI<A>) -> *mut BTreeMap<IRI<A>, BTreeSet<AA>> {
-        self.irindex.borrow_mut().entry(iri.clone()).or_default();
-        self.irindex.as_ptr()
-    }
-
     /// Fetch the axioms for the given iri.
     fn set_for_iri(&self, iri: &IRI<A>) -> Option<&BTreeSet<AA>> {
-        unsafe { (*self.irindex.as_ptr()).get(iri) }
+        self.irindex.get(iri)
     }
 
     /// Fetch the axioms for given iri as a mutable ref.
     fn mut_set_for_iri(&mut self, iri: &IRI<A>) -> &mut BTreeSet<AA> {
-        unsafe { (*self.components_as_ptr(iri)).get_mut(iri).unwrap() }
+        self.irindex.entry(iri.clone()).or_default()
     }
 
     /*
@@ -324,13 +312,12 @@ impl<A: ForIRI, AA: ForIndex<A>> From<IRIMappedOntology<A, AA>> for SetOntology<
 
 #[cfg(test)]
 mod test {
-    use super::{IRIMappedIndex, IRIMappedOntology};
+    use super::{ArcIRIMappedOntology, IRIMappedIndex, IRIMappedOntology};
     use crate::{model::*, ontology::indexed::OntologyIndex};
 
     #[test]
     fn test_ontology_cons() {
         let _ = IRIMappedOntology::new_arc();
-        assert!(true);
     }
 
     #[test]
@@ -441,14 +428,20 @@ mod test {
         i.index_insert(RcAnnotatedComponent::new(disj1.clone()));
         i.index_remove(&disj1);
 
-        let irindex = i.irindex.borrow();
+        let irindex = &i.irindex;
 
         let mut v: Vec<_> = irindex
             .iter()
-            .flat_map(|(i, s)| s.into_iter().map(move |c| (i.clone(), c.clone())))
+            .flat_map(|(i, s)| s.iter().map(move |c| (i.clone(), c.clone())))
             .collect();
         v.sort();
 
         assert_eq!(v, Vec::<(IRI<RcStr>, RcAnnotatedComponent)>::new())
+    }
+
+    #[test]
+    fn test_once_lock_ontology() {
+        let _: std::cell::RefCell<ArcIRIMappedOntology> = std::cell::RefCell::default();
+        let _: std::sync::OnceLock<ArcIRIMappedOntology> = std::sync::OnceLock::new();
     }
 }


### PR DESCRIPTION
Addresses #126.

It is now possible to wrap `ArcIRIMappedOntology` using `OnceLock`, `Mutex` etc.
Additionally, this change removes some unsafe code that was needed to access the `BTreeMap` that was wrapped in a `RefCell`. 

I added `test_once_lock_ontology()` to mimic the behavior showed by @KonradHoeffner in #126, which now passes.