### PR TITLE
new tool: horned validate.

### DIFF
--- a/horned-bin/Cargo.toml
+++ b/horned-bin/Cargo.toml
@@ -66,3 +66,7 @@ path = "src/bin/horned_triples.rs"
 [[bin]]
 name = "horned-unparsed"
 path = "src/bin/horned_unparsed.rs"
+
+[[bin]]
+name = "horned-validate"
+path = "src/bin/horned_validate.rs"

--- a/horned-bin/src/bin/horned.rs
+++ b/horned-bin/src/bin/horned.rs
@@ -12,6 +12,7 @@ mod horned_round;
 mod horned_summary;
 mod horned_triples;
 mod horned_unparsed;
+mod horned_validate;
 
 fn main() -> Result<(), HornedError> {
     let matches = app().get_matches();
@@ -34,6 +35,7 @@ fn app() -> App<'static> {
         .subcommand(horned_summary::app("summary"))
         .subcommand(horned_triples::app("triples"))
         .subcommand(horned_unparsed::app("unparsed"))
+        .subcommand(horned_validate::app("validate"))
 }
 
 fn matcher(matches: ArgMatches) -> Result<(), HornedError> {
@@ -48,6 +50,7 @@ fn matcher(matches: ArgMatches) -> Result<(), HornedError> {
             "summary" => horned_summary::matcher(submatches),
             "triples" => horned_triples::matcher(submatches),
             "unparsed" => horned_unparsed::matcher(submatches),
+            "validate" => horned_validate::matcher(submatches),
             _ => todo!(),
         }
     } else {

--- a/horned-bin/src/bin/horned_unparsed.rs
+++ b/horned-bin/src/bin/horned_unparsed.rs
@@ -44,17 +44,7 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
             parser_config(matches),
         )?;
 
-    println!("\n\nIncompleted Parsed");
-    println!("\tSimple Triples: {:#?}", incomplete.simple);
-    println!("\tbnode: {:#?}", incomplete.bnode);
-    println!("\tsequences: {:#?}", incomplete.bnode_seq);
-    println!("\tClass Expressions: {:#?}", incomplete.class_expression);
-    println!(
-        "\tObject Property Expressions: {:#?}",
-        incomplete.object_property_expression
-    );
-    println!("\tData Range: {:#?}", incomplete.data_range);
-    println!("\tAnnotations: {:#?}", incomplete.ann_map);
+    horned_bin::validation::write_incomplete(incomplete);
 
     Ok(())
 }

--- a/horned-bin/src/bin/horned_validate.rs
+++ b/horned-bin/src/bin/horned_validate.rs
@@ -1,0 +1,54 @@
+extern crate clap;
+extern crate horned_owl;
+
+use clap::App;
+use clap::Arg;
+use clap::ArgMatches;
+
+use horned_bin::{
+    config::{parser_app, parser_config},
+    parse_path,
+};
+
+use horned_owl::error::HornedError;
+
+use std::path::Path;
+
+#[allow(dead_code)]
+fn main() -> Result<(), HornedError> {
+    let matches = app("horned-validate").get_matches();
+    matcher(&matches)
+}
+
+pub(crate) fn app(name: &str) -> App<'static> {
+    parser_app(
+        App::new(name)
+            .version("0.1")
+            .about("Validates an ontology against the OWL2 specification")
+            .author("Filippo De Bortoli")
+            .arg(
+                Arg::with_name("INPUT")
+                    .help("Sets the input file to use")
+                    .required(true)
+                    .index(1),
+            ),
+    )
+}
+
+pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
+    let input = matches
+        .value_of("INPUT")
+        .ok_or_else(horned_bin::error::error_missing_input)?;
+
+    let incomplete = parse_path(Path::new(input), parser_config(matches))?
+        .decompose()
+        .2;
+
+    if let Some(incomplete) = incomplete {
+        horned_bin::validation::write_incomplete(incomplete);
+        Err(HornedError::CommandError("Validation failed".to_string()))
+    } else {
+        println!("Validation was successful.");
+        Ok(())
+    }
+}

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -17,6 +17,14 @@ use std::{
     path::Path,
 };
 
+pub mod error {
+    use super::*;
+
+    pub fn error_missing_input() -> HornedError {
+        HornedError::CommandError("Command requires an INPUT parameter".to_string())
+    }
+}
+
 pub fn write<A: ForIRI, AA: ForIndex<A>, W: StdWrite>(
     format: &str,
     write: &mut W,
@@ -200,6 +208,24 @@ pub mod naming {
             AnnotationPropertyRange => "Annotation Property Range",
             Rule => "Rule",
         }
+    }
+}
+
+pub mod validation {
+    use horned_owl::{io::rdf::reader::IncompleteParse, model::ForIRI};
+
+    pub fn write_incomplete<T: ForIRI>(incomplete: IncompleteParse<T>) {
+        println!("\n\nIncompleted Parsed");
+        println!("\tSimple Triples: {:#?}", incomplete.simple);
+        println!("\tbnode: {:#?}", incomplete.bnode);
+        println!("\tsequences: {:#?}", incomplete.bnode_seq);
+        println!("\tClass Expressions: {:#?}", incomplete.class_expression);
+        println!(
+            "\tObject Property Expressions: {:#?}",
+            incomplete.object_property_expression
+        );
+        println!("\tData Range: {:#?}", incomplete.data_range);
+        println!("\tAnnotations: {:#?}", incomplete.ann_map);
     }
 }
 

--- a/horned-bin/tests/test_horned_validate.rs
+++ b/horned-bin/tests/test_horned_validate.rs
@@ -1,0 +1,22 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use std::process::Command; // Run programs
+
+#[test]
+fn integration_validate_ontology_rdf() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("horned-validate")?;
+
+    cmd.arg("../src/ont/owl-rdf/and.owl");
+    cmd.assert().success();
+
+    Ok(())
+}
+
+#[test]
+fn integration_validate_ontology_xml() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("horned-validate")?;
+
+    cmd.arg("../src/ont/owl-xml/and.owx");
+    cmd.assert().success();
+
+    Ok(())
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -67,7 +67,9 @@ impl<A: ForIRI, AA: ForIndex<A>> ParserOutput<A, AA> {
         match self {
             ParserOutput::OFNParser(o, m) => (o, Some(m), None),
             ParserOutput::OWXParser(o, m) => (o, Some(m), None),
-            ParserOutput::RDFParser(o, i) => (o.into(), None, Some(i)),
+            ParserOutput::RDFParser(o, i) => {
+                (o.into(), None, if i.is_complete() { None } else { Some(i) })
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses #135.
It essentially combines `horned parse` and `horned unparsed`.
If no incomplete parse is present, then the program exits successfully.
If an incomplete parse is found, it will be printed and the program will exit with 1.

- The RDF parser was returning an incomplete parse even if the ontology was parsed successfully, I changed that behavior so that if the parse is complete then there is no incomplete parse returned after decomposing the parser.
- It is very rudimental for now: everything is printed on STDOUT. Ideally, we could print the unfinished part on STDERR. 