### PR TITLE
resolve: changes return type and signature of localize_iri

### DIFF
--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -126,12 +126,12 @@ pub fn materialize_1<'a>(
     let amont: RcComponentMappedOntology = parse_imports(Path::new(input), config)?.into();
     let import = amont.i().import();
 
-    let b = Build::new_rc();
+    let _b = Build::new_rc();
 
     // Get all the imports
     for i in import {
         if !done.contains(&i.0) {
-            let local: String = localize_iri(&i.0, &b.iri(input)).into();
+            let local: String = localize_iri(&i.0, input);
             let local_path = Path::new(&local);
             if !local_path.exists() {
                 println!("Retrieving Ontology: {}", &i.0);

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -88,19 +88,18 @@ pub fn as_local_path_buffer<A: ForIRI>(iri: &IRI<A>) -> Option<PathBuf> {
 /// let doc_iri = b.iri("file://base_dir/and.owl");
 /// let iri = b.iri("http://www.example.com/or.owl");
 ///
-/// let local = b.iri("file://base_dir/or.owl");
+/// let local = String::from("file://base_dir/or.owl");
 ///
 /// assert_eq!(localize_iri(&iri, &doc_iri), local);
 /// ```
-pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &IRI<A>) -> IRI<A> {
-    let b = Build::new();
+pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &str) -> String {
     let (_, term_iri) = iri.split_at(iri.rfind('/').unwrap() + 1);
 
-    b.iri(if let Some(index) = doc_iri.rfind('/') {
+    if let Some(index) = doc_iri.rfind('/') {
         format!("{}/{}", doc_iri.split_at(index).0, term_iri)
     } else {
         format!("./{}", term_iri)
-    })
+    }
 }
 
 /// Return contents of an IRI as a string
@@ -111,7 +110,8 @@ pub fn resolve_iri<A: ForIRI>(
     doc_iri: Option<&IRI<A>>,
 ) -> Result<(IRI<A>, String), HornedError> {
     let local = if let Some(doc_iri) = doc_iri {
-        localize_iri(iri, doc_iri)
+        let b = Build::new();
+        b.iri(localize_iri(iri, doc_iri))
     } else {
         iri.clone()
     };
@@ -171,7 +171,7 @@ mod test {
 
         let iri = b.iri("http://www.example.com/or.owl");
 
-        let local = b.iri("file://base_dir/or.owl");
+        let local = String::from("file://base_dir/or.owl");
 
         assert_eq!(localize_iri(&iri, &doc_iri), local);
     }


### PR DESCRIPTION
This is a small change to the signature and return type of `resolve:localize_iri()`.

It previously required the argument `doc_iri` to be `IRI<A>`, but the actual usage of this method suggests that `doc_iri` can simply be a `str`, avoiding the unnecessary creation of a IRI builder and the allocation of an IRI in `materialize_1`.

Additionally, we can return a `String` (or potentially even a `Path`) instead of an IRI, thus avoiding a second time the creation of an IRI builder for allocating an IRI.

@phillord is there any objection to merging? The idea would be to incrementally rebuild this method to be effective in locating imports also using catalogs as mentioned in #144 and [this issue for py-horned-owl](https://github.com/ontology-tools/py-horned-owl/issues/43).