### PR TITLE
add panic message when ontology URI cannot be imported

### DIFF
--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -124,7 +124,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> ClosureOntologyParse
         let import_iris = self.import_map.get(iri).unwrap();
         let import_closure: Vec<_> = import_iris
             .iter()
-            .map(|i| self.op.get(i).unwrap().ontology_ref())
+            .map(|i| {
+                self.op
+                    .get(i)
+                    .unwrap_or_else(|| panic!("failed to import ontology IRI {}", i))
+                    .ontology_ref()
+            })
             .collect();
 
         // The import closure references ontologies in the op


### PR DESCRIPTION
When an ontology cannot be imported the user currently just gets a panic without explanation which makes troubleshooting very difficult.
As a first step of solving issue #153, this PR adds a more helpful message.