### PR TITLE
upgrade Rust edition from 2018 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities", "parsing",
 
 license = "LGPL-3.0"
 edition = "2024"
+rust-version = "1.88"
 
 [dependencies]
 curie = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["command-line-utilities", "parsing",
               "rendering", "science", "data-structures"]
 
 license = "LGPL-3.0"
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 curie = "0.1.1"

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -12,7 +12,7 @@ fn io_read(c: &mut Criterion) {
     for n in [10, 100, 1_000, 2500, 5000, 10_000].iter() {
         group.bench_with_input(BenchmarkId::new("owl_io_read", n), n, |b, &n| {
             b.iter(|| {
-                let f = File::open(format!("benches/ont/o{}.owl", n)).ok().unwrap();
+                let f = File::open(format!("benches/ont/o{n}.owl")).ok().unwrap();
                 let mut f = BufReader::new(f);
                 let _ = horned_owl::io::rdf::reader::read(&mut f, Default::default()).ok();
             })
@@ -20,7 +20,7 @@ fn io_read(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("owx_io_read", n), n, |b, &n| {
             b.iter(|| {
-                let f = File::open(format!("benches/ont/o{}.owx", n)).ok().unwrap();
+                let f = File::open(format!("benches/ont/o{n}.owx")).ok().unwrap();
                 let mut f = BufReader::new(f);
                 let _: (SetOntology<RcStr>, _) =
                     horned_owl::io::owx::reader::read(&mut f, Default::default())

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration, criterion_group};
 use horned_owl::model::RcStr;
 use horned_owl::ontology::set::SetOntology;
 use std::fs::File;

--- a/benches/model.rs
+++ b/benches/model.rs
@@ -18,7 +18,7 @@ fn create_many_classes(i: isize) {
     let b = Build::new_rc();
     let mut o = SetOntology::new();
     for m in 1..i {
-        let i = b.iri(format!("http://example.com/b{}", m));
+        let i = b.iri(format!("http://example.com/b{m}"));
         let _c = o.declare(b.class(i));
     }
 }
@@ -36,7 +36,7 @@ fn classes(c: &mut Criterion) {
 }
 
 fn create_tree<A: ForIRI, O: MutableOntology<A>>(b: &Build<A>, o: &mut O, n: isize) {
-    let i = b.iri(format!("http://example.com/a{}", n));
+    let i = b.iri(format!("http://example.com/a{n}"));
     let c = b.class(i);
     create_tree_0(b, o, vec![c], n);
 }
@@ -50,10 +50,10 @@ fn create_tree_0<A: ForIRI, O: MutableOntology<A>>(
     let mut next = vec![];
 
     for curr in current.into_iter() {
-        let i = b.iri(format!("http://example.com/a{}", remaining));
+        let i = b.iri(format!("http://example.com/a{remaining}"));
         let c = b.class(i);
         remaining -= 1;
-        let i = b.iri(format!("http://example.com/a{}", remaining));
+        let i = b.iri(format!("http://example.com/a{remaining}"));
         let d = b.class(i);
         remaining -= 1;
 

--- a/benches/model.rs
+++ b/benches/model.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 use std::rc::Rc;
 
-use criterion::{criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration, criterion_group};
 
 use horned_owl::io::rdf::reader::ConcreteRDFOntology;
 use horned_owl::model::*;

--- a/horned-bin/Cargo.toml
+++ b/horned-bin/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "parsing",
               "rendering", "science", "data-structures"]
 
 license = "LGPL-3.0"
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 clap = "3.2.2"

--- a/horned-bin/src/bin/horned_big.rs
+++ b/horned-bin/src/bin/horned_big.rs
@@ -1,7 +1,7 @@
-use clap::arg;
 use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
+use clap::arg;
 
 use horned_bin::write;
 

--- a/horned-bin/src/bin/horned_big.rs
+++ b/horned-bin/src/bin/horned_big.rs
@@ -55,7 +55,7 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
     });
 
     for i in 1..size + 1 {
-        o.declare(b.class(format!("https://www.example.com/o{}", i)));
+        o.declare(b.class(format!("https://www.example.com/o{i}")));
     }
 
     let amo: RcComponentMappedOntology = o.into();

--- a/horned-bin/src/bin/horned_dump.rs
+++ b/horned-bin/src/bin/horned_dump.rs
@@ -46,21 +46,21 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
     match r {
         horned_owl::io::ParserOutput::OFNParser(ont, map) => {
             let hash_map: HashMap<&String, &String> = map.mappings().collect();
-            println!("Ontology:\n{:#?}\n\nMapping:\n{:#?}", ont, hash_map);
+            println!("Ontology:\n{ont:#?}\n\nMapping:\n{hash_map:#?}");
             Ok(())
         }
         horned_owl::io::ParserOutput::OWXParser(ont, map) => {
             let hash_map: HashMap<&String, &String> = map.mappings().collect();
-            println!("Ontology:\n{:#?}\n\nMapping:\n{:#?}", ont, hash_map);
+            println!("Ontology:\n{ont:#?}\n\nMapping:\n{hash_map:#?}");
             Ok(())
         }
         horned_owl::io::ParserOutput::RDFParser(ont, inc) => {
             if !matches.is_present("incomplete") {
                 let so: SetOntology<_> = ont.into();
-                println!("Ontology:\n{:#?}", so);
+                println!("Ontology:\n{so:#?}");
             }
 
-            println!("Incomplete Parse:\n{:#?}", inc);
+            println!("Incomplete Parse:\n{inc:#?}");
             Ok(())
         }
     }

--- a/horned-bin/src/bin/horned_materialize.rs
+++ b/horned-bin/src/bin/horned_materialize.rs
@@ -42,7 +42,7 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
 
     println!("Materialized");
     for i in v {
-        println!("\t{:?}", i);
+        println!("\t{i:?}");
     }
 
     Ok(())

--- a/horned-bin/src/bin/horned_parse.rs
+++ b/horned-bin/src/bin/horned_parse.rs
@@ -42,6 +42,6 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
 
     parse_path(Path::new(input), parser_config(matches))?;
 
-    println!("Parse Complete: {:?}", input);
+    println!("Parse Complete: {input:?}");
     Ok(())
 }

--- a/horned-bin/src/bin/horned_triples.rs
+++ b/horned-bin/src/bin/horned_triples.rs
@@ -76,7 +76,7 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
         .collect();
 
     for t in v {
-        println!("{}", t);
+        println!("{t}");
     }
 
     if matches.is_present("round") {

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -34,8 +34,7 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: StdWrite>(
         "owx" => horned_owl::io::owx::writer::write(write, ont, None),
         "owl" => horned_owl::io::rdf::writer::write(write, ont),
         _ => Err(HornedError::CommandError(format!(
-            "Format is unknown: {}",
-            format
+            "Format is unknown: {format}"
         ))),
     }
 }
@@ -71,8 +70,7 @@ pub fn parse_path(
         }
         None => {
             return Err(HornedError::CommandError(format!(
-                "Cannot parse a file of this format: {:?}",
-                path
+                "Cannot parse a file of this format: {path:?}"
             )));
         }
     })
@@ -100,8 +98,7 @@ pub fn parse_imports(
         }
         None => {
             return Err(HornedError::CommandError(format!(
-                "Cannot parse a file of this format: {:?}",
-                path
+                "Cannot parse a file of this format: {path:?}"
             )));
         }
     })
@@ -122,7 +119,7 @@ pub fn materialize_1<'a>(
     done: &'a mut Vec<IRI<RcStr>>,
     recurse: bool,
 ) -> Result<&'a mut Vec<IRI<RcStr>>, HornedError> {
-    println!("Parsing: {}", input);
+    println!("Parsing: {input}");
     let amont: RcComponentMappedOntology = parse_imports(Path::new(input), config)?.into();
     let import = amont.i().import();
 
@@ -137,11 +134,11 @@ pub fn materialize_1<'a>(
                 println!("Retrieving Ontology: {}", &i.0);
                 let imported_data = strict_resolve_iri(&i.0)?;
                 done.push(i.0.clone());
-                println!("Saving to {}", local);
+                println!("Saving to {local}");
                 let mut file = File::create(&local)?;
                 file.write_all(imported_data.as_bytes())?;
             } else {
-                println!("Already Present: {}", local);
+                println!("Already Present: {local}");
             }
             if recurse {
                 materialize_1(&local, config, done, true)?;

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -3,7 +3,7 @@
 use horned_owl::{
     error::HornedError,
     io::{ParserConfiguration, ParserOutput, ResourceType},
-    model::{Build, ForIRI, RcAnnotatedComponent, RcStr, IRI},
+    model::{Build, ForIRI, IRI, RcAnnotatedComponent, RcStr},
     ontology::{
         component_mapped::{ComponentMappedOntology, RcComponentMappedOntology},
         indexed::ForIndex,
@@ -102,7 +102,7 @@ pub fn parse_imports(
             return Err(HornedError::CommandError(format!(
                 "Cannot parse a file of this format: {:?}",
                 path
-            )))
+            )));
         }
     })
 }

--- a/src/adaptor.rs
+++ b/src/adaptor.rs
@@ -6,8 +6,6 @@
 //! provides parsing and validation support.
 use crate::model::ForIRI;
 
-use std::convert::TryInto;
-
 impl<A: ForIRI> crate::model::IRI<A> {
     pub fn as_oxiri(&self) -> Result<oxiri::Iri<&str>, oxiri::IriParseError> {
         oxiri::Iri::parse(self.0.borrow())
@@ -25,8 +23,6 @@ impl<'a, A: ForIRI> TryInto<oxiri::Iri<&'a str>> for &'a crate::model::IRI<A> {
 #[cfg(test)]
 mod test {
     use crate::model::Build;
-
-    use std::convert::TryInto;
 
     #[test]
     fn test_oxiri() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ impl<'i> From<pest::Span<'i>> for Location {
 impl Display for Location {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BytePosition(u) => write!(f, "Byte Position: {}", u),
+            Self::BytePosition(u) => write!(f, "Byte Position: {u}"),
             Self::ByteSpan(r) => write!(f, "Byte Span: {} to {}", r.start, r.end),
             Self::Unknown => write!(f, "Unknown"),
         }

--- a/src/io/ofn/reader/from_pair.rs
+++ b/src/io/ofn/reader/from_pair.rs
@@ -1283,7 +1283,7 @@ mod tests {
     fn from_pair_resource(resource: &str) {
         let text = &slurp::read_all_to_string(resource).unwrap();
         let pair = match OwlFunctionalLexer::lex(Rule::OntologyDocument, text.trim()) {
-            Err(e) => panic!("parser failed: {}", e),
+            Err(e) => panic!("parser failed: {e}"),
             Ok(mut pairs) => {
                 let pair = pairs.next().unwrap();
                 assert_eq!(pair.as_str(), text.trim());

--- a/src/io/ofn/reader/from_pair.rs
+++ b/src/io/ofn/reader/from_pair.rs
@@ -9,7 +9,7 @@ use pest::iterators::Pair;
 
 use crate::error::HornedError;
 use crate::model::*;
-use crate::vocab::{Facet, OWL2Datatype, OWL};
+use crate::vocab::{Facet, OWL, OWL2Datatype};
 
 use super::Context;
 use super::Rule;
@@ -1122,7 +1122,7 @@ mod tests {
     use test_generator::test_resources;
 
     macro_rules! assert_parse_into {
-        ($ty:ty, $rule:path, $build:ident, $prefixes:ident, $doc:expr, $expected:expr) => {
+        ($ty:ty, $rule:path, $build:ident, $prefixes:ident, $doc:expr_2021, $expected:expr_2021) => {
             let doc = $doc.trim();
             let ctx = Context::new(&$build, &$prefixes);
             match OwlFunctionalLexer::lex($rule, doc) {
@@ -1305,6 +1305,6 @@ mod tests {
             crate::io::owx::reader::read(&mut Cursor::new(&owx), Default::default()).unwrap();
 
         // pretty_assertions::assert_eq!(item.1, expected.1);
-        pretty_assertions::assert_eq!(item.0 .0, expected.0);
+        pretty_assertions::assert_eq!(item.0.0, expected.0);
     }
 }

--- a/src/io/ofn/reader/from_pair.rs
+++ b/src/io/ofn/reader/from_pair.rs
@@ -1122,7 +1122,7 @@ mod tests {
     use test_generator::test_resources;
 
     macro_rules! assert_parse_into {
-        ($ty:ty, $rule:path, $build:ident, $prefixes:ident, $doc:expr_2021, $expected:expr_2021) => {
+        ($ty:ty, $rule:path, $build:ident, $prefixes:ident, $doc:expr, $expected:expr_2021) => {
             let doc = $doc.trim();
             let ctx = Context::new(&$build, &$prefixes);
             match OwlFunctionalLexer::lex($rule, doc) {

--- a/src/io/ofn/reader/lexer.rs
+++ b/src/io/ofn/reader/lexer.rs
@@ -20,7 +20,7 @@ impl OwlFunctionalLexer {
     ///
     /// [`Rule`]: ./enum.Rule.html
     /// [`pest::Parser::parse`]: https://docs.rs/pest/latest/pest/trait.Parser.html
-    pub fn lex(rule: Rule, input: &str) -> Result<Pairs<Rule>, HornedError> {
+    pub fn lex(rule: Rule, input: &str) -> Result<Pairs<'_, Rule>, HornedError> {
         <Self as pest::Parser<Rule>>::parse(rule, input).map_err(From::from)
     }
 }

--- a/src/io/ofn/reader/lexer.rs
+++ b/src/io/ofn/reader/lexer.rs
@@ -36,7 +36,7 @@ pub mod test {
         let ont_s = slurp::read_all_to_string(resource).unwrap();
         match OwlFunctionalLexer::lex(Rule::OntologyDocument, ont_s.trim()) {
             Ok(mut pairs) => assert_eq!(pairs.next().unwrap().as_str(), ont_s.trim()),
-            Err(e) => panic!("parser failed: {}", e),
+            Err(e) => panic!("parser failed: {e}"),
         }
     }
 }

--- a/src/io/ofn/reader/mod.rs
+++ b/src/io/ofn/reader/mod.rs
@@ -52,5 +52,5 @@ pub fn read_with_build<A: ForIRI, O: MutableOntology<A> + Ontology<A> + Default,
 
     let wrapper: Result<(MutableOntologyWrapper<A, O>, PrefixMapping), HornedError> =
         FromPair::from_pair(pair, &ctx);
-    wrapper.map(|r| (r.0 .0, r.1))
+    wrapper.map(|r| (r.0.0, r.1))
 }

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -867,7 +867,7 @@ impl<A: ForIRI> Display for Functional<'_, IRI<A>, A> {
         if let Some(prefixes) = self.1.as_ref() {
             match prefixes.shrink_iri(self.0) {
                 Err(_) => write!(f, "<{}>", self.0),
-                Ok(curie) => write!(f, "{}", curie),
+                Ok(curie) => write!(f, "{curie}"),
             }
         } else {
             write!(f, "<{}>", self.0)
@@ -916,7 +916,7 @@ impl<A: ForIRI> Display for Functional<'_, Literal<A>, A> {
             Literal::Simple { literal } => quote(literal, f),
             Literal::Language { literal, lang } => {
                 quote(literal, f)?;
-                write!(f, "@{}", lang)
+                write!(f, "@{lang}")
             }
             Literal::Datatype {
                 literal,
@@ -1009,7 +1009,7 @@ impl<A: ForIRI> AsFunctional<A> for Variable<A> {}
 impl<A: ForIRI> Display for Functional<'_, curie::PrefixMapping, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         for (name, value) in self.0.mappings() {
-            writeln!(f, "Prefix({}:=<{}>)", name, value)?;
+            writeln!(f, "Prefix({name}:=<{value}>)")?;
         }
         Ok(())
     }

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -108,7 +108,7 @@ macro_rules! derive_tuple1 {
     ($A:ident, $t:ty) => {
         impl<'a, $A: ForIRI> Display for Functional<'a, (&$t,), $A> {
             fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-                write!(f, "{}", Functional(self.0 .0, self.1, None),)
+                write!(f, "{}", Functional(self.0.0, self.1, None),)
             }
         }
     };
@@ -129,8 +129,8 @@ macro_rules! derive_tuple2 {
                 write!(
                     f,
                     "{} {}",
-                    Functional(self.0 .0, self.1, None),
-                    Functional(self.0 .1, self.1, None),
+                    Functional(self.0.0, self.1, None),
+                    Functional(self.0.1, self.1, None),
                 )
             }
         }
@@ -165,9 +165,9 @@ macro_rules! derive_tuple3 {
                 write!(
                     f,
                     "{} {} {}",
-                    Functional(self.0 .0, self.1, None),
-                    Functional(self.0 .1, self.1, None),
-                    Functional(self.0 .2, self.1, None),
+                    Functional(self.0.0, self.1, None),
+                    Functional(self.0.1, self.1, None),
+                    Functional(self.0.2, self.1, None),
                 )
             }
         }
@@ -202,13 +202,13 @@ macro_rules! derive_declaration {
                         f,
                         concat!("Declaration({} ", stringify!($name), "({}))"),
                         Functional(annotations, self.1, None),
-                        Functional(&self.0 .0, self.1, None)
+                        Functional(&self.0.0, self.1, None)
                     )
                 } else {
                     write!(
                         f,
                         concat!("Declaration(", stringify!($name), "({}))"),
-                        Functional(&self.0 .0, self.1, None)
+                        Functional(&self.0.0, self.1, None)
                     )
                 }
             }
@@ -246,7 +246,7 @@ macro_rules! derive_wrapper {
     ($A:ident, $ty:ty) => {
         impl<'a, $A: ForIRI> Display for Functional<'a, $ty, $A> {
             fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-                write!(f, "{}", Functional(&self.0 .0, self.1, None))
+                write!(f, "{}", Functional(&self.0.0, self.1, None))
             }
         }
 
@@ -440,7 +440,7 @@ impl<A: ForIRI> AsFunctional<A> for AnnotationValue<A> {}
 
 impl<A: ForIRI> Display for Functional<'_, AnonymousIndividual<A>, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(f, "{}", self.0 .0.borrow())
+        write!(f, "{}", self.0.0.borrow())
     }
 }
 
@@ -998,7 +998,7 @@ impl<A: ForIRI> AsFunctional<A> for SubObjectPropertyExpression<A> {}
 
 impl<A: ForIRI> Display for Functional<'_, Variable<A>, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(f, "Variable({})", Functional(&self.0 .0, self.1, None))
+        write!(f, "Variable({})", Functional(&self.0.0, self.1, None))
     }
 }
 
@@ -1036,7 +1036,7 @@ impl<A: ForIRI> AsFunctional<A> for OntologyID<A> {}
 
 impl<A: ForIRI> Display for Functional<'_, DocIRI<A>, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        Functional(&self.0 .0, self.1, None).fmt(f)
+        Functional(&self.0.0, self.1, None).fmt(f)
     }
 }
 

--- a/src/io/ofn/writer/mod.rs
+++ b/src/io/ofn/writer/mod.rs
@@ -101,7 +101,7 @@ mod test {
 
     #[test_resources("src/ont/owl-functional/*.ofn")]
     fn roundtrip_resource(resource: &str) {
-        let reader = std::fs::File::open(&resource)
+        let reader = std::fs::File::open(resource)
             .map(std::io::BufReader::new)
             .unwrap();
         let (ont, prefixes): (ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>, _) =

--- a/src/io/ofn/writer/mod.rs
+++ b/src/io/ofn/writer/mod.rs
@@ -59,14 +59,14 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: Write>(
     write!(write, "Ontology(")?;
 
     // Write the IRI and Version IRI if any
-    if let Some(ontology_id) = optional_id {
-        if let Some(iri) = &ontology_id.iri {
-            write!(write, "{}", iri.as_functional_with_prefixes(mapping))?;
-            if let Some(viri) = &ontology_id.viri {
-                writeln!(write, " {}", viri.as_functional_with_prefixes(mapping))?;
-            } else {
-                writeln!(write)?;
-            }
+    if let Some(ontology_id) = optional_id
+        && let Some(iri) = &ontology_id.iri
+    {
+        write!(write, "{}", iri.as_functional_with_prefixes(mapping))?;
+        if let Some(viri) = &ontology_id.viri {
+            writeln!(write, " {}", viri.as_functional_with_prefixes(mapping))?;
+        } else {
+            writeln!(write)?;
         }
     }
 

--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -13,7 +13,6 @@ use crate::vocab::OWL2Datatype;
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
-use std::convert::TryFrom;
 use std::io::BufRead;
 
 use quick_xml::NsReader;

--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -8,18 +8,18 @@ use crate::io::ParserConfiguration;
 use crate::model::*;
 use crate::vocab::Facet;
 use crate::vocab::Namespace::*;
-use crate::vocab::OWL2Datatype;
 use crate::vocab::OWL;
+use crate::vocab::OWL2Datatype;
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::convert::TryFrom;
 use std::io::BufRead;
 
+use quick_xml::NsReader;
 use quick_xml::events::BytesEnd;
 use quick_xml::events::BytesStart;
 use quick_xml::events::Event;
-use quick_xml::NsReader;
 
 struct Read<'a, A: ForIRI, R>
 where
@@ -371,9 +371,8 @@ from_start! {
         let mut literal = String::new();
         let mut buf = Vec::new();
         loop {
-            if let Event::End(event) = r.reader.read_event_into(&mut buf)? {
-                if let b"Literal" = event.local_name().as_ref() { break; }
-            }
+            if let Event::End(event) = r.reader.read_event_into(&mut buf)?
+                && let b"Literal" = event.local_name().as_ref() { break; }
 
             // This decoding step is not sufficient on its own.
             // For instance, "A --> B" would yield "A --&gt; B".
@@ -2040,9 +2039,14 @@ pub mod test {
         let cl = &ont.i().sub_class_of().next().unwrap().sup;
         assert_eq!(ont.i().sub_class_of().count(), 1);
 
-        assert!(
-            matches!(cl, ClassExpression::DataExactCardinality { n: ref _n, dp: ref _dp, dr: ref _dr })
-        );
+        assert!(matches!(
+            cl,
+            ClassExpression::DataExactCardinality {
+                n: _n,
+                dp: _dp,
+                dr: _dr
+            }
+        ));
     }
 
     #[test]
@@ -2052,15 +2056,15 @@ pub mod test {
         let cl = &ont.i().sub_class_of().next().unwrap().sup;
         assert_eq!(ont.i().sub_class_of().count(), 1);
 
-        assert!(
-            matches!(cl, ClassExpression::DataExactCardinality { n: ref _n, dp: ref _dp, dr: ref _dr })
-        );
-        if let ClassExpression::DataExactCardinality {
-            n: ref _n,
-            dp: ref _dp,
-            ref dr,
-        } = cl
-        {
+        assert!(matches!(
+            cl,
+            ClassExpression::DataExactCardinality {
+                n: _n,
+                dp: _dp,
+                dr: _dr
+            }
+        ));
+        if let ClassExpression::DataExactCardinality { n: _n, dp: _dp, dr } = cl {
             assert!(match dr {
                 DataRange::Datatype(dt) => {
                     dt.is(&OWL2Datatype::Literal)
@@ -2080,9 +2084,14 @@ pub mod test {
         let cl = &ont.i().sub_class_of().next().unwrap().sup;
         assert_eq!(ont.i().sub_class_of().count(), 1);
 
-        assert!(
-            matches!(cl, ClassExpression::DataMinCardinality { n: ref _n, dp: ref _dp, dr: ref _dr })
-        );
+        assert!(matches!(
+            cl,
+            ClassExpression::DataMinCardinality {
+                n: _n,
+                dp: _dp,
+                dr: _dr
+            }
+        ));
     }
 
     #[test]
@@ -2093,9 +2102,14 @@ pub mod test {
         let cl = &ont.i().sub_class_of().next().unwrap().sup;
         assert_eq!(ont.i().sub_class_of().count(), 1);
 
-        assert!(
-            matches!(cl, ClassExpression::DataMaxCardinality { n: ref _n, dp: ref _dp, dr: ref _dr })
-        );
+        assert!(matches!(
+            cl,
+            ClassExpression::DataMaxCardinality {
+                n: _n,
+                dp: _dp,
+                dr: _dr
+            }
+        ));
     }
 
     #[test]

--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -674,7 +674,7 @@ fn data_cardinality_restriction<A: ForIRI, R: BufRead>(
     end_tag: &[u8],
 ) -> Result<(u32, DataProperty<A>, DataRange<A>), HornedError> {
     let n = get_attr_value_str(&mut r.reader, e, b"cardinality")?;
-    let n = n.ok_or_else(|| (error_missing_attribute("cardinality", r)))?;
+    let n = n.ok_or_else(|| error_missing_attribute("cardinality", r))?;
 
     let dp = from_next(r)?;
     let mut vdr: Vec<DataRange<_>> = till_end(r, end_tag)?;

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -209,7 +209,7 @@ macro_rules! render {
 }
 
 macro_rules! contents {
-    ($type:ident, $self:ident, $body:expr_2021) => {
+    ($type:ident, $self:ident, $body:expr) => {
         render! {$type, $self, w, m,{
                 $body.render(w, m)?;
                 Ok(())

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -1,7 +1,6 @@
 use curie::PrefixMapping;
 
 use crate::error::HornedError;
-use crate::model::Kinded;
 use crate::model::*;
 use crate::ontology::component_mapped::ComponentMappedOntology;
 use crate::ontology::indexed::ForIndex;

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -7,12 +7,12 @@ use crate::ontology::component_mapped::ComponentMappedOntology;
 use crate::ontology::indexed::ForIndex;
 use crate::vocab::Namespace::*;
 
+use quick_xml::Writer;
 use quick_xml::events::BytesDecl;
 use quick_xml::events::BytesEnd;
 use quick_xml::events::BytesStart;
 use quick_xml::events::BytesText;
 use quick_xml::events::Event;
-use quick_xml::Writer;
 
 use std::collections::BTreeSet;
 use std::io::Write as StdWrite;
@@ -210,7 +210,7 @@ macro_rules! render {
 }
 
 macro_rules! contents {
-    ($type:ident, $self:ident, $body:expr) => {
+    ($type:ident, $self:ident, $body:expr_2021) => {
         render! {$type, $self, w, m,{
                 $body.render(w, m)?;
                 Ok(())
@@ -970,8 +970,8 @@ mod test {
 
     use self::mktemp::Temp;
     use super::*;
-    use crate::io::owx::reader::*;
     use crate::io::ParserConfiguration;
+    use crate::io::owx::reader::*;
 
     use std::collections::HashMap;
 

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -61,7 +61,7 @@ where
 fn iri_or_curie(mapping: &PrefixMapping, elem: &mut BytesStart, iri: &str) {
     match mapping.shrink_iri(&(*iri)[..]) {
         Ok(curie) => {
-            let curie = format!("{}", curie);
+            let curie = format!("{curie}");
             elem.push_attribute(("abbreviatedIRI", &curie[..]));
         }
         Err(_) => elem.push_attribute(("IRI", iri)),

--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -1,9 +1,9 @@
 use crate::error::HornedError;
-use crate::io::rdf::reader::parser_with_build;
-use crate::io::rdf::reader::OntologyParser;
-use crate::io::rdf::reader::RDFOntology;
 use crate::io::IncompleteParse;
 use crate::io::ParserConfiguration;
+use crate::io::rdf::reader::OntologyParser;
+use crate::io::rdf::reader::RDFOntology;
+use crate::io::rdf::reader::parser_with_build;
 use crate::model::Build;
 use crate::model::DocIRI;
 use crate::model::ForIRI;
@@ -96,10 +96,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> ClosureOntologyParse
 
         let si: &SetIndex<A, AA> = o.as_ref();
 
-        let mut res = if let Some(declared_iri) = si.the_ontology_id_or_default().iri {
-            vec![declared_iri]
-        } else {
-            vec![]
+        let mut res = match si.the_ontology_id_or_default().iri {
+            Some(declared_iri) => {
+                vec![declared_iri]
+            }
+            _ => {
+                vec![]
+            }
         };
 
         if let Some(declared_iri) = si.the_ontology_id_or_default().iri {

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -33,7 +33,7 @@ use std::{io::BufRead, marker::PhantomData};
 type RioTerm<'a> = ::rio_api::model::Term<'a>;
 
 macro_rules! ok_some {
-    ($body:expr_2021) => {
+    ($body:expr) => {
         (if let Some(retn) = (|| Some($body))() {
             Ok(Some(retn))
         } else {

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -1,24 +1,24 @@
+use Term::*;
 use rio_api::{
     model::{BlankNode, NamedNode, Subject, Triple},
     parser::TriplesParser,
 };
-use Term::*;
 
 use crate::{error::HornedError, io::ParserConfiguration, vocab::Facet};
 use crate::{model::Literal, ontology::component_mapped::ComponentMappedOntology};
 use crate::{model::*, vocab::Vocab};
 
 use crate::ontology::indexed::ForIndex;
-use crate::vocab::is_annotation_builtin;
-use crate::vocab::OWL2Datatype;
 use crate::vocab::OWL as VOWL;
+use crate::vocab::OWL2Datatype;
 use crate::vocab::RDF as VRDF;
 use crate::vocab::SWRL as VSWRL;
+use crate::vocab::is_annotation_builtin;
 use crate::{
     ontology::{
         declaration_mapped::DeclarationMappedIndex,
         indexed::ThreeIndexedOntology,
-        logically_equal::{update_or_insert_logically_equal_component, LogicallyEqualIndex},
+        logically_equal::{LogicallyEqualIndex, update_or_insert_logically_equal_component},
         set::{SetIndex, SetOntology},
     },
     resolve::strict_resolve_iri,
@@ -33,7 +33,7 @@ use std::{io::BufRead, marker::PhantomData};
 type RioTerm<'a> = ::rio_api::model::Term<'a>;
 
 macro_rules! ok_some {
-    ($body:expr) => {
+    ($body:expr_2021) => {
         (if let Some(retn) = (|| Some($body))() {
             Ok(Some(retn))
         } else {
@@ -196,10 +196,9 @@ impl<A: ForIRI> Build<A> {
     }
 
     fn to_term_nn(&self, nn: &NamedNode) -> Term<A> {
-        if let Ok(term) = nn.try_into() {
-            term
-        } else {
-            Term::Iri(self.iri(nn.iri))
+        match nn.try_into() {
+            Ok(term) => term,
+            _ => Term::Iri(self.iri(nn.iri)),
         }
     }
 
@@ -214,18 +213,15 @@ impl<A: ForIRI> Build<A> {
                     lang: language.to_string(),
                 })
             }
-            rio_api::model::Literal::Typed { value, datatype } => {
-                if let Ok(crate::vocab::XSD::String) = datatype.try_into() {
-                    Term::Literal(Literal::Simple {
-                        literal: value.to_string(),
-                    })
-                } else {
-                    Term::Literal(Literal::Datatype {
-                        literal: value.to_string(),
-                        datatype_iri: self.iri(datatype.iri),
-                    })
-                }
-            }
+            rio_api::model::Literal::Typed { value, datatype } => match datatype.try_into() {
+                Ok(crate::vocab::XSD::String) => Term::Literal(Literal::Simple {
+                    literal: value.to_string(),
+                }),
+                _ => Term::Literal(Literal::Datatype {
+                    literal: value.to_string(),
+                    datatype_iri: self.iri(datatype.iri),
+                }),
+            },
         }
     }
 }
@@ -537,10 +533,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
 
         for (k, v) in std::mem::take(&mut self.bnode) {
             match v.as_slice() {
-                [[_, Term::RDF(VRDF::First), val],
-                 [_, Term::RDF(VRDF::Rest), Term::BNode(bnode_id)],
-                 // Some sequences have a Type List, some do not
-                 ..
+                [
+                    [_, Term::RDF(VRDF::First), val],
+                    [_, Term::RDF(VRDF::Rest), Term::BNode(bnode_id)],
+                    // Some sequences have a Type List, some do not
+                    ..,
                 ] => {
                     let some_seq = self.bnode_seq.remove(bnode_id);
                     if let Some(mut seq) = some_seq {
@@ -565,12 +562,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
     fn stitch_seqs(&mut self) {
         for (k, v) in std::mem::take(&mut self.bnode) {
             match v.as_slice() {
-                [[_, Term::RDF(VRDF::First), val],
-                 [_, Term::RDF(VRDF::Rest), Term::RDF(VRDF::Nil)],
-                 // Lists may or may not have a "list" RDF type
-                 ..
-                ] =>
-                {
+                [
+                    [_, Term::RDF(VRDF::First), val],
+                    [_, Term::RDF(VRDF::Rest), Term::RDF(VRDF::Nil)],
+                    // Lists may or may not have a "list" RDF type
+                    ..,
+                ] => {
                     self.bnode_seq.insert(k.clone(), vec![val.clone()]);
                 }
                 _ => {
@@ -614,7 +611,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
 
         for t in std::mem::take(&mut self.simple) {
             match t.0 {
-                [Term::Iri(s), Term::RDF(VRDF::Type), Term::OWL(VOWL::Ontology)] => {
+                [
+                    Term::Iri(s),
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::Ontology),
+                ] => {
                     iri = Some(s.clone());
                 }
                 [Term::Iri(s), Term::OWL(VOWL::VersionIRI), Term::Iri(ob)]
@@ -682,11 +683,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
     fn axiom_annotations(&mut self) {
         for (k, v) in std::mem::take(&mut self.bnode) {
             match v.as_slice() {
-                [[_, Term::OWL(VOWL::AnnotatedProperty), p],//:
-                 [_, Term::OWL(VOWL::AnnotatedSource), sb],//:
-                 [_, Term::OWL(VOWL::AnnotatedTarget), ob],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Axiom)], ann @ ..] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::AnnotatedProperty), p], //:
+                    [_, Term::OWL(VOWL::AnnotatedSource), sb],  //:
+                    [_, Term::OWL(VOWL::AnnotatedTarget), ob],  //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Axiom)],
+                    ann @ ..,
+                ] => {
                     self.ann_map.insert(
                         [sb.clone(), p.clone(), ob.clone()],
                         self.parse_annotations(ann),
@@ -752,46 +755,51 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
 
         for (this_bnode, v) in std::mem::take(&mut self.bnode) {
             let dr: Result<_, HornedError> = match v.as_slice() {
-                [[_, Term::OWL(VOWL::IntersectionOf), Term::BNode(bnodeid)],//: rustfmt hard line!
-                 [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::IntersectionOf), Term::BNode(bnodeid)], //: rustfmt hard line!
+                    [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)],
+                ] => {
                     ok_some! {
                         DataRange::DataIntersectionOf(
                             self.fetch_dr_seq(bnodeid)?
                         )
                     }
                 }
-                [[_, Term::OWL(VOWL::UnionOf), Term::BNode(bnodeid)],//: rustfmt hard line!
-                 [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::UnionOf), Term::BNode(bnodeid)], //: rustfmt hard line!
+                    [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)],
+                ] => {
                     ok_some! {
                         DataRange::DataUnionOf(
                             self.fetch_dr_seq(bnodeid)?
                         )
                     }
                 }
-                [[_, Term::OWL(VOWL::DatatypeComplementOf), term],//:
-                 [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::DatatypeComplementOf), term], //:
+                    [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)],
+                ] => {
                     ok_some! {
                       DataRange::DataComplementOf(
                             Box::new(self.fetch_dr(term)?)
                         )
                     }
                 }
-                [[_, Term::OWL(VOWL::OneOf), Term::BNode(bnode)],//:
-                 [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::OneOf), Term::BNode(bnode)], //:
+                    [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)],
+                ] => {
                     ok_some! {
                         DataRange::DataOneOf(
                             self.fetch_literal_seq(bnode)?
                         )
                     }
                 }
-                [[_, Term::OWL(VOWL::OnDatatype), Term::Iri(iri)],//:
-                 [_, Term::OWL(VOWL::WithRestrictions), Term::BNode(id)],//:
-                 [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::OnDatatype), Term::Iri(iri)], //:
+                    [_, Term::OWL(VOWL::WithRestrictions), Term::BNode(id)], //:
+                    [_, Term::RDF(VRDF::Type), Term::RDFS(VRDFS::Datatype)],
+                ] => {
                     ok_some! {
                         {
                             let facet_seq = self.bnode_seq
@@ -820,10 +828,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 _ => Ok(None),
             };
 
-            if let Some(dr) = dr? {
-                self.data_range.insert(this_bnode, dr);
-            } else {
-                self.bnode.insert(this_bnode, v);
+            match dr? {
+                Some(dr) => {
+                    self.data_range.insert(this_bnode, dr);
+                }
+                _ => {
+                    self.bnode.insert(this_bnode, v);
+                }
             }
         }
 
@@ -1069,9 +1080,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
             // rustfmt breaks this (putting the triples all on one
             // line) so skip
             let ce: Result<_, HornedError> = match v.as_slice() {
-                [[_, Term::OWL(VOWL::OnProperty), pr],//:
-                 [_, Term::OWL(VOWL::SomeValuesFrom), ce_or_dr],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]] => {
+                [
+                    [_, Term::OWL(VOWL::OnProperty), pr],           //:
+                    [_, Term::OWL(VOWL::SomeValuesFrom), ce_or_dr], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1089,10 +1102,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                             _ => panic!("Unexpected Property Kind")
                         }
                     }
-                },
-                [[_, Term::OWL(VOWL::HasValue), val],//:
-                 [_, Term::OWL(VOWL::OnProperty), pr],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]] => {
+                }
+                [
+                    [_, Term::OWL(VOWL::HasValue), val],  //:
+                    [_, Term::OWL(VOWL::OnProperty), pr], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1110,10 +1125,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                             _ => panic!("Unexpected Property kind"),
                         }
                     }
-                },
-                [[_, Term::OWL(VOWL::AllValuesFrom), ce_or_dr],//:
-                 [_, Term::OWL(VOWL::OnProperty), pr],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]] => {
+                }
+                [
+                    [_, Term::OWL(VOWL::AllValuesFrom), ce_or_dr], //:
+                    [_, Term::OWL(VOWL::OnProperty), pr],          //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1131,56 +1148,67 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                             _ => panic!("Unexpected Property Kind")
                         }
                     }
-                },
-                [[_, Term::OWL(VOWL::OneOf), Term::BNode(bnodeid)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)]] => {
-                    ok_some!{
+                }
+                [
+                    [_, Term::OWL(VOWL::OneOf), Term::BNode(bnodeid)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)],
+                ] => {
+                    ok_some! {
                         ClassExpression::ObjectOneOf(
                             self.fetch_ni_seq(bnodeid)?
                         )
                     }
-                 },
-                 [[_, Term::OWL(VOWL::HasSelf), _],//:
-                  [_, Term::OWL(VOWL::OnProperty), pr],
-                  [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]] => {
-                    ok_some!{
+                }
+                [
+                    [_, Term::OWL(VOWL::HasSelf), _], //:
+                    [_, Term::OWL(VOWL::OnProperty), pr],
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
+                ] => {
+                    ok_some! {
                         ClassExpression::ObjectHasSelf(
                             self.fetch_ope(pr, ic)?
                         )
                     }
                 }
-                [[_, Term::OWL(VOWL::IntersectionOf), Term::BNode(bnodeid)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)]] => {
-                    ok_some!{
+                [
+                    [_, Term::OWL(VOWL::IntersectionOf), Term::BNode(bnodeid)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)],
+                ] => {
+                    ok_some! {
                         ClassExpression::ObjectIntersectionOf(
                             self.fetch_ce_seq(bnodeid)?
                         )
                     }
-                },
-                [[_, Term::OWL(VOWL::UnionOf), Term::BNode(bnodeid)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)]] => {
-                    ok_some!{
+                }
+                [
+                    [_, Term::OWL(VOWL::UnionOf), Term::BNode(bnodeid)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)],
+                ] => {
+                    ok_some! {
                         ClassExpression::ObjectUnionOf(
                             self.fetch_ce_seq(
                                 bnodeid,
                             )?
                         )
                     }
-                },
-                [[_, Term::OWL(VOWL::ComplementOf), tce],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)]] => {
-                    ok_some!{
+                }
+                [
+                    [_, Term::OWL(VOWL::ComplementOf), tce], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Class)],
+                ] => {
+                    ok_some! {
                         ClassExpression::ObjectComplementOf(
                             self.fetch_ce(tce)?.into()
                         )
                     }
-                },
-                [[_, Term::OWL(VOWL::OnDataRange), dr],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::OWL(VOWL::QualifiedCardinality), literal],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                }
+                [
+                    [_, Term::OWL(VOWL::OnDataRange), dr],               //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],     //:
+                    [_, Term::OWL(VOWL::QualifiedCardinality), literal], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::DataExactCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1189,12 +1217,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::MaxQualifiedCardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnDataRange), dr],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::MaxQualifiedCardinality), literal], //:
+                    [_, Term::OWL(VOWL::OnDataRange), dr],                  //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],        //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::DataMaxCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1203,12 +1232,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::MinQualifiedCardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnDataRange), dr],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::MinQualifiedCardinality), literal], //:
+                    [_, Term::OWL(VOWL::OnDataRange), dr],                  //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],        //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::DataMinCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1221,11 +1251,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 //_:x owl:cardinality NN_INT(n) .
                 //_:x owl:onProperty y .
                 //{ OPE(y) ≠ ε }
-                [[_, Term::OWL(VOWL::Cardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnProperty), pr],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::Cardinality), literal], //:
+                    [_, Term::OWL(VOWL::OnProperty), pr],       //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
                                 ClassExpression::ObjectExactCardinality
@@ -1249,12 +1280,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::OnClass), tce],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::OWL(VOWL::QualifiedCardinality), literal],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::OnClass), tce],                  //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],     //:
+                    [_, Term::OWL(VOWL::QualifiedCardinality), literal], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::ObjectExactCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1263,11 +1295,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::MinCardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::MinCardinality), literal],   //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::ObjectMinCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1276,12 +1309,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::MinQualifiedCardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnClass), tce],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::MinQualifiedCardinality), literal], //:
+                    [_, Term::OWL(VOWL::OnClass), tce],                     //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],        //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::ObjectMinCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1290,11 +1324,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::MaxCardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::MaxCardinality), literal],   //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::ObjectMaxCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1303,12 +1338,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::MaxQualifiedCardinality), literal],//:
-                 [_, Term::OWL(VOWL::OnClass), tce],//:
-                 [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)]
+                [
+                    [_, Term::OWL(VOWL::MaxQualifiedCardinality), literal], //:
+                    [_, Term::OWL(VOWL::OnClass), tce],                     //:
+                    [_, Term::OWL(VOWL::OnProperty), Term::Iri(pr)],        //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::Restriction)],
                 ] => {
-                    ok_some!{
+                    ok_some! {
                         ClassExpression::ObjectMaxCardinality
                         {
                             n:self.fetch_u32(literal)?,
@@ -1320,11 +1356,14 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 _a => Ok(None),
             };
 
-            if let Some(ce) = ce? {
-                self.class_expression.insert(this_bnode, ce);
-                parsed_new_ce = true;
-            } else {
-                self.bnode.insert(this_bnode, v);
+            match ce? {
+                Some(ce) => {
+                    self.class_expression.insert(this_bnode, ce);
+                    parsed_new_ce = true;
+                }
+                _ => {
+                    self.bnode.insert(this_bnode, v);
+                }
             }
         }
 
@@ -1340,11 +1379,16 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
 
         for (this_bnode, v) in std::mem::take(&mut self.bnode) {
             let axiom: Result<_, HornedError> = match v.as_slice() {
-                [[_, Term::OWL(VOWL::AssertionProperty), pr],//:
-                 [_, Term::OWL(VOWL::SourceIndividual), Term::Iri(i)],//:
-                 [_, target_type, target],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::NegativePropertyAssertion)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::AssertionProperty), pr],          //:
+                    [_, Term::OWL(VOWL::SourceIndividual), Term::Iri(i)], //:
+                    [_, target_type, target],                             //:
+                    [
+                        _,
+                        Term::RDF(VRDF::Type),
+                        Term::OWL(VOWL::NegativePropertyAssertion),
+                    ],
+                ] => {
                     ok_some! {
                         match target_type {
                             Term::OWL(VOWL::TargetIndividual) =>
@@ -1363,18 +1407,20 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::OWL(VOWL::Members), Term::BNode(bnodeid)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::AllDifferent)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::Members), Term::BNode(bnodeid)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::AllDifferent)],
+                ] => {
                     ok_some! {
                         DifferentIndividuals (
                             self.fetch_ni_seq(bnodeid)?
                         ).into()
                     }
                 }
-                [[_, Term::OWL(VOWL::DistinctMembers), Term::BNode(bnodeid)],//:
-                 [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::AllDifferent)]] =>
-                {
+                [
+                    [_, Term::OWL(VOWL::DistinctMembers), Term::BNode(bnodeid)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::AllDifferent)],
+                ] => {
                     ok_some! {
                         DifferentIndividuals (
                             self.fetch_ni_seq(bnodeid)?
@@ -1384,15 +1430,18 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 _ => Ok(None),
             };
 
-            if let Some(axiom) = axiom? {
-                self.merge(AnnotatedComponent {
+            match axiom? {
+                Some(axiom) => self.merge(AnnotatedComponent {
                     component: axiom,
                     ann: BTreeSet::new(),
-                })
-            } else if v.len() == 1 {
-                single_bnodes.push(v[0].clone());
-            } else {
-                self.bnode.insert(this_bnode, v);
+                }),
+                _ => {
+                    if v.len() == 1 {
+                        single_bnodes.push(v[0].clone());
+                    } else {
+                        self.bnode.insert(this_bnode, v);
+                    }
+                }
             }
         }
 
@@ -1458,7 +1507,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [Term::Iri(iri), Term::OWL(VOWL::DisjointUnionOf), Term::BNode(bnodeid)] => {
+                [
+                    Term::Iri(iri),
+                    Term::OWL(VOWL::DisjointUnionOf),
+                    Term::BNode(bnodeid),
+                ] => {
                     ok_some! {
                         DisjointUnion(
                             Class(iri.clone()),
@@ -1470,12 +1523,20 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                     InverseObjectProperties(ObjectProperty(p.clone()), ObjectProperty(r.clone()))
                         .into(),
                 )),
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::TransitiveProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::TransitiveProperty),
+                ] => {
                     ok_some! {
                         TransitiveObjectProperty(self.fetch_ope(pr, ic)?).into()
                     }
                 }
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::FunctionalProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::FunctionalProperty),
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1488,7 +1549,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::AsymmetricProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::AsymmetricProperty),
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1499,7 +1564,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::SymmetricProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::SymmetricProperty),
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1510,7 +1579,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::ReflexiveProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::ReflexiveProperty),
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1521,7 +1594,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::IrreflexiveProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::IrreflexiveProperty),
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1532,7 +1609,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [pr, Term::RDF(VRDF::Type), Term::OWL(VOWL::InverseFunctionalProperty)] => {
+                [
+                    pr,
+                    Term::RDF(VRDF::Type),
+                    Term::OWL(VOWL::InverseFunctionalProperty),
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pr, ic)? {
                             PropertyExpression::ObjectPropertyExpression(ope) => {
@@ -1578,7 +1659,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [Term::Iri(pr), Term::OWL(VOWL::PropertyChainAxiom), Term::BNode(id)] => {
+                [
+                    Term::Iri(pr),
+                    Term::OWL(VOWL::PropertyChainAxiom),
+                    Term::BNode(id),
+                ] => {
                     ok_some! {
                         SubObjectPropertyOf {
                             sub: SubObjectPropertyExpression::ObjectPropertyChain(
@@ -1700,14 +1785,15 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 _ => Ok(None),
             };
 
-            if let Some(axiom) = axiom? {
-                let ann = self.ann_map.remove(&triple.0).unwrap_or_default();
-                self.merge(AnnotatedComponent {
-                    component: axiom,
-                    ann,
-                })
-            } else {
-                self.simple.push(triple)
+            match axiom? {
+                Some(axiom) => {
+                    let ann = self.ann_map.remove(&triple.0).unwrap_or_default();
+                    self.merge(AnnotatedComponent {
+                        component: axiom,
+                        ann,
+                    })
+                }
+                _ => self.simple.push(triple),
             }
         }
 
@@ -1718,7 +1804,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
         // identify variables first
         for triple in std::mem::take(&mut self.simple) {
             match &triple.0 {
-                [Term::Iri(s), Term::RDF(VRDF::Type), Term::SWRL(VSWRL::Variable)] => {
+                [
+                    Term::Iri(s),
+                    Term::RDF(VRDF::Type),
+                    Term::SWRL(VSWRL::Variable),
+                ] => {
                     self.variable.insert(s.clone(), Variable(s.clone()));
                 }
                 _ => {
@@ -1730,8 +1820,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
         // Next identify the atoms with a big pattern matcher over bnodes
         for (bnode, triple) in std::mem::take(&mut self.bnode) {
             let atom: Result<_, HornedError> = match triple.as_slice() {
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::ClassAtom)], [_, Term::SWRL(VSWRL::Argument1), arg], [_, Term::SWRL(VSWRL::ClassPredicate), pred]] =>
-                {
+                [
+                    [_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::ClassAtom)],
+                    [_, Term::SWRL(VSWRL::Argument1), arg],
+                    [_, Term::SWRL(VSWRL::ClassPredicate), pred],
+                ] => {
                     ok_some! {
                         {
                             Atom::ClassAtom{
@@ -1741,8 +1834,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::DataRangeAtom)], [_, Term::SWRL(VSWRL::Argument1), arg], [_, Term::SWRL(VSWRL::DataRange), pred]] =>
-                {
+                [
+                    [_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::DataRangeAtom)],
+                    [_, Term::SWRL(VSWRL::Argument1), arg],
+                    [_, Term::SWRL(VSWRL::DataRange), pred],
+                ] => {
                     ok_some! {
                         {
                             Atom::DataRangeAtom{
@@ -1752,8 +1848,16 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::IndividualPropertyAtom)], [_, Term::SWRL(VSWRL::Argument1), arg1], [_, Term::SWRL(VSWRL::Argument2), arg2], [_, Term::SWRL(VSWRL::PropertyPredicate), pred]] =>
-                {
+                [
+                    [
+                        _,
+                        Term::RDF(VRDF::Type),
+                        Term::SWRL(VSWRL::IndividualPropertyAtom),
+                    ],
+                    [_, Term::SWRL(VSWRL::Argument1), arg1],
+                    [_, Term::SWRL(VSWRL::Argument2), arg2],
+                    [_, Term::SWRL(VSWRL::PropertyPredicate), pred],
+                ] => {
                     ok_some! {
                         match self.find_property_kind(pred, ic)? {
                             PropertyExpression::ObjectPropertyExpression(pred) => {
@@ -1769,8 +1873,16 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::DatavaluedPropertyAtom)], [_, Term::SWRL(VSWRL::Argument1), arg1], [_, Term::SWRL(VSWRL::Argument2), arg2], [_, Term::SWRL(VSWRL::PropertyPredicate), pred]] =>
-                {
+                [
+                    [
+                        _,
+                        Term::RDF(VRDF::Type),
+                        Term::SWRL(VSWRL::DatavaluedPropertyAtom),
+                    ],
+                    [_, Term::SWRL(VSWRL::Argument1), arg1],
+                    [_, Term::SWRL(VSWRL::Argument2), arg2],
+                    [_, Term::SWRL(VSWRL::PropertyPredicate), pred],
+                ] => {
                     ok_some! {
                         Atom::DataPropertyAtom {
                             pred: self.fetch_dp(pred, ic)?,
@@ -1781,8 +1893,15 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         }
                     }
                 }
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::DifferentIndividualsAtom)], [_, Term::SWRL(VSWRL::Argument1), arg1], [_, Term::SWRL(VSWRL::Argument2), arg2]] =>
-                {
+                [
+                    [
+                        _,
+                        Term::RDF(VRDF::Type),
+                        Term::SWRL(VSWRL::DifferentIndividualsAtom),
+                    ],
+                    [_, Term::SWRL(VSWRL::Argument1), arg1],
+                    [_, Term::SWRL(VSWRL::Argument2), arg2],
+                ] => {
                     ok_some! {
                         Atom::DifferentIndividualsAtom(
                             self.to_iargument(arg1, ic)?,
@@ -1790,8 +1909,15 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         )
                     }
                 }
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::SameIndividualAtom)], [_, Term::SWRL(VSWRL::Argument1), arg1], [_, Term::SWRL(VSWRL::Argument2), arg2]] =>
-                {
+                [
+                    [
+                        _,
+                        Term::RDF(VRDF::Type),
+                        Term::SWRL(VSWRL::SameIndividualAtom),
+                    ],
+                    [_, Term::SWRL(VSWRL::Argument1), arg1],
+                    [_, Term::SWRL(VSWRL::Argument2), arg2],
+                ] => {
                     ok_some! {
                         Atom::SameIndividualAtom(
                             self.to_iargument(arg1, ic)?,
@@ -1799,8 +1925,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         )
                     }
                 }
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::BuiltinAtom)], [_, Term::SWRL(VSWRL::Arguments), Term::BNode(args)], [_, Term::SWRL(VSWRL::Builtin), Term::Iri(iri)]] =>
-                {
+                [
+                    [_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::BuiltinAtom)],
+                    [_, Term::SWRL(VSWRL::Arguments), Term::BNode(args)],
+                    [_, Term::SWRL(VSWRL::Builtin), Term::Iri(iri)],
+                ] => {
                     ok_some! {
                         Atom::BuiltInAtom{
                             pred: iri.clone(),
@@ -1811,10 +1940,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 _ => Ok(None),
             };
 
-            if let Some(atom) = atom? {
-                self.atom.insert(Term::BNode(bnode), atom);
-            } else {
-                self.bnode.insert(bnode, triple);
+            match atom? {
+                Some(atom) => {
+                    self.atom.insert(Term::BNode(bnode), atom);
+                }
+                _ => {
+                    self.bnode.insert(bnode, triple);
+                }
             }
         }
 
@@ -1823,8 +1955,11 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
         // entire rule
         for (bnode, triple) in std::mem::take(&mut self.bnode) {
             let rule: Result<_, HornedError> = match triple.as_slice() {
-                [[_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::Imp)], [_, Term::SWRL(VSWRL::Body), Term::BNode(body_bn)], [_, Term::SWRL(VSWRL::Head), Term::BNode(head_bn)]] =>
-                {
+                [
+                    [_, Term::RDF(VRDF::Type), Term::SWRL(VSWRL::Imp)],
+                    [_, Term::SWRL(VSWRL::Body), Term::BNode(body_bn)],
+                    [_, Term::SWRL(VSWRL::Head), Term::BNode(head_bn)],
+                ] => {
                     ok_some! {
                         Rule {
                             head: self.fetch_atom_seq(head_bn)?,
@@ -1835,10 +1970,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 _ => Ok(None),
             };
 
-            if let Some(rule) = rule? {
-                self.merge(rule);
-            } else {
-                self.bnode.insert(bnode, triple);
+            match rule? {
+                Some(rule) => {
+                    self.merge(rule);
+                }
+                _ => {
+                    self.bnode.insert(bnode, triple);
+                }
             }
         }
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -2299,7 +2299,7 @@ mod test {
         let r = read(bufread, Default::default());
 
         if let Err(e) = r {
-            panic!("Expected ontology, get failure: {:?}", e,);
+            panic!("Expected ontology, get failure: {e:?}",);
         }
 
         let (ont, incomp) = r.unwrap();
@@ -2321,10 +2321,8 @@ mod test {
         let dir = dir_path_buf.parent().unwrap().to_string_lossy();
 
         compare_str(
-            &slurp::read_all_to_string(format!("{}/../../ont/owl-rdf/{}.owl", dir, testrdf))
-                .unwrap(),
-            &slurp::read_all_to_string(format!("{}/../../ont/owl-xml/{}.owx", dir, testowl))
-                .unwrap(),
+            &slurp::read_all_to_string(format!("{dir}/../../ont/owl-rdf/{testrdf}.owl")).unwrap(),
+            &slurp::read_all_to_string(format!("{dir}/../../ont/owl-xml/{testowl}.owx")).unwrap(),
         );
     }
 
@@ -2332,7 +2330,7 @@ mod test {
         let dir_path_buf = PathBuf::from(file!());
         let dir = dir_path_buf.parent().unwrap().to_string_lossy();
 
-        slurp::read_all_to_string(format!("{}/../../ont/owl-rdf/{}.owl", dir, testrdf)).unwrap()
+        slurp::read_all_to_string(format!("{dir}/../../ont/owl-rdf/{testrdf}.owl")).unwrap()
     }
 
     fn compare_str(rdfread: &str, xmlread: &str) {

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -122,6 +122,7 @@ impl<A: ForIRI> TryFrom<&crate::vocab::Vocab> for Term<A> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
 enum OrTerm<A: ForIRI> {
     Term(Term<A>),
     ClassExpression(ClassExpression<A>),

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -25,9 +25,9 @@ use crate::{
     vocab::RDFS as VRDFS,
 };
 
+use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::io::Cursor;
-use std::{collections::BTreeSet, convert::TryFrom};
-use std::{collections::HashMap, convert::TryInto};
 use std::{io::BufRead, marker::PhantomData};
 
 type RioTerm<'a> = ::rio_api::model::Term<'a>;

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -1,9 +1,9 @@
 use crate::{
-    error::invalid,
     error::HornedError,
+    error::invalid,
     model::*,
     ontology::component_mapped::ComponentMappedOntology,
-    vocab::{Vocab, OWL, RDF, RDFS, SWRL, XSD},
+    vocab::{OWL, RDF, RDFS, SWRL, Vocab, XSD},
 };
 
 use crate::ontology::indexed::ForIndex;
@@ -239,7 +239,7 @@ macro_rules! render_to_vec {
 
 /// Render to a single triple
 macro_rules! render_triple {
-    ($type:ident, $self:ident, $ng:ident, $sub:expr, $pred:expr, $ob:expr) => {
+    ($type:ident, $self:ident, $ng:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
         render! {
             $type, $self, f, $ng, PTriple,
             {
@@ -251,7 +251,7 @@ macro_rules! render_triple {
 
 /// Generate and write a triple
 macro_rules! triple {
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr) => {{
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {{
         let t = to_triple($sub, $pred, $ob);
         $f.format(t.clone())?;
         t
@@ -261,12 +261,12 @@ macro_rules! triple {
 /// Generate many triples
 macro_rules! triples {
     ($f:ident) => {};
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr) => {
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
         $f.format(to_triple(
                  $sub, $pred, $ob
         ))?;
      };
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr, $($rest:expr),+) => {
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
         triples!($f, $sub, $pred, $ob);
         triples!($f, $($rest),*);
     }
@@ -275,7 +275,7 @@ macro_rules! triples {
 /// Generate and write many triples and return the first
 macro_rules! triples_to_node {
     ($f:ident) => {};
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr) => {
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
         {
             let s = $sub;
 
@@ -286,7 +286,7 @@ macro_rules! triples_to_node {
             s
         }
     };
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr, $($rest:expr),+) => {
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
         {
             let s = triples_to_node!($f, $sub, $pred, $ob);
             triples!($f, $($rest),*);
@@ -299,7 +299,7 @@ macro_rules! triples_to_node {
 /// Generate and write many triples and return all as a vec
 macro_rules! triples_to_vec {
     ($f:ident) => {};
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr) => {
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
         {
             let t = to_triple($sub, $pred, $ob);
             $f.format(t.clone())?;
@@ -307,7 +307,7 @@ macro_rules! triples_to_vec {
             vec![t]
         }
      };
-    ($f:ident, $sub:expr, $pred:expr, $ob:expr, $($rest:expr),+) => {
+    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
         {
             let mut v = triples_to_vec!($f, $sub, $pred, $ob);
             v.extend(triples_to_vec!($f, $($rest),*));
@@ -360,10 +360,13 @@ fn render_vec_subject<
 
         triples!(f, bn.clone(), ng.nn(RDF::First), item);
 
-        if let Some(r) = rest.take() {
-            triples!(f, bn.clone(), ng.nn(RDF::Rest), r);
-        } else {
-            triples!(f, bn.clone(), ng.nn(RDF::Rest), ng.nn(RDF::Nil));
+        match rest.take() {
+            Some(r) => {
+                triples!(f, bn.clone(), ng.nn(RDF::Rest), r);
+            }
+            _ => {
+                triples!(f, bn.clone(), ng.nn(RDF::Rest), ng.nn(RDF::Nil));
+            }
         }
         rest = Some(bn.clone())
     }
@@ -384,10 +387,13 @@ where
 
             triples!(f, bn.clone(), ng.nn(RDF::First), item);
 
-            if let Some(r) = rest.take() {
-                triples!(f, bn.clone(), ng.nn(RDF::Rest), r);
-            } else {
-                triples!(f, bn.clone(), ng.nn(RDF::Rest), ng.nn(RDF::Nil));
+            match rest.take() {
+                Some(r) => {
+                    triples!(f, bn.clone(), ng.nn(RDF::Rest), r);
+                }
+                _ => {
+                    triples!(f, bn.clone(), ng.nn(RDF::Rest), ng.nn(RDF::Nil));
+                }
             }
             rest = Some(bn.clone().into())
         }
@@ -1134,11 +1140,11 @@ fn obj_cardinality<A: ForIRI, F: RdfXmlFormatter<A, W>, W: Write>(
         node_ope
     );
 
-    if let ClassExpression::Class(ref cl) = *ce {
-        if cl.is_thing() {
-            triples!(f, bn.clone(), unqual, node_n);
-            return Ok(bn);
-        }
+    if let ClassExpression::Class(ref cl) = *ce
+        && cl.is_thing()
+    {
+        triples!(f, bn.clone(), unqual, node_n);
+        return Ok(bn);
     }
     let node_ce: PTerm<_> = ce.render(f, ng)?.into();
 
@@ -1238,7 +1244,7 @@ render_to_node! {
                         bn, ng.nn(OWL::OneOf), node_seq
                     )
                 }
-                Self::ObjectSomeValuesFrom{ref bce, ref ope} => {
+                Self::ObjectSomeValuesFrom{bce, ope} => {
                     let bn = ng.bn();
                     let node_ce:PTerm<_> = bce.render(f, ng)?.into();
                     let node_ope:PTerm<_> = ope.render(f, ng)?.into();

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -1125,7 +1125,7 @@ fn obj_cardinality<A: ForIRI, F: RdfXmlFormatter<A, W>, W: Write>(
     let bn = ng.bn();
     let node_ope: PTerm<_> = ope.render(f, ng)?.into();
     let node_n = PTerm::Literal(PLiteral::Typed {
-        value: format!("{}", n).into(),
+        value: format!("{n}").into(),
         datatype: ng.nn(XSD::NonNegativeInteger),
     });
 
@@ -1174,7 +1174,7 @@ fn data_cardinality<A: ForIRI, F: RdfXmlFormatter<A, W>, W: Write>(
     let bn = ng.bn();
     let node_dp: PTerm<_> = (&dp.0).into();
     let node_n = PTerm::Literal(PLiteral::Typed {
-        value: format!("{}", n).into(),
+        value: format!("{n}").into(),
         datatype: ng.nn(XSD::NonNegativeInteger),
     });
     let node_dr: PTerm<_> = dr.render(f, ng)?.into();
@@ -1778,8 +1778,7 @@ mod test {
 
         assert!(
             incomplete.is_complete(),
-            "Read Not Complete: {:#?}",
-            incomplete
+            "Read Not Complete: {incomplete:#?}"
         );
         o.into()
     }
@@ -1836,8 +1835,8 @@ mod test {
     fn assert_round(ont: &str) -> (SetOntology<RcStr>, SetOntology<RcStr>) {
         let (ont_orig, ont_round) = roundtrip(ont);
 
-        println!("ont_orig\n{:#?}", ont_orig);
-        println!("ont_round\n{:#?}", ont_round);
+        println!("ont_orig\n{ont_orig:#?}");
+        println!("ont_round\n{ont_round:#?}");
         assert_eq!(ont_orig, ont_round);
 
         (ont_orig, ont_round)
@@ -1847,7 +1846,7 @@ mod test {
     #[test_resources("src/ont/owl-rdf/ambiguous/*.owl")]
     fn roundtrip_rdf(resource: &str) {
         let resource = &slurp::read_all_to_string(resource).unwrap();
-        assert_round(&resource);
+        assert_round(resource);
     }
 
     #[test]

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -239,7 +239,7 @@ macro_rules! render_to_vec {
 
 /// Render to a single triple
 macro_rules! render_triple {
-    ($type:ident, $self:ident, $ng:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
+    ($type:ident, $self:ident, $ng:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021) => {
         render! {
             $type, $self, f, $ng, PTriple,
             {
@@ -251,7 +251,7 @@ macro_rules! render_triple {
 
 /// Generate and write a triple
 macro_rules! triple {
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {{
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021) => {{
         let t = to_triple($sub, $pred, $ob);
         $f.format(t.clone())?;
         t
@@ -261,12 +261,12 @@ macro_rules! triple {
 /// Generate many triples
 macro_rules! triples {
     ($f:ident) => {};
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021) => {
         $f.format(to_triple(
                  $sub, $pred, $ob
         ))?;
      };
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
         triples!($f, $sub, $pred, $ob);
         triples!($f, $($rest),*);
     }
@@ -275,7 +275,7 @@ macro_rules! triples {
 /// Generate and write many triples and return the first
 macro_rules! triples_to_node {
     ($f:ident) => {};
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021) => {
         {
             let s = $sub;
 
@@ -286,7 +286,7 @@ macro_rules! triples_to_node {
             s
         }
     };
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
         {
             let s = triples_to_node!($f, $sub, $pred, $ob);
             triples!($f, $($rest),*);
@@ -299,7 +299,7 @@ macro_rules! triples_to_node {
 /// Generate and write many triples and return all as a vec
 macro_rules! triples_to_vec {
     ($f:ident) => {};
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021) => {
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021) => {
         {
             let t = to_triple($sub, $pred, $ob);
             $f.format(t.clone())?;
@@ -307,7 +307,7 @@ macro_rules! triples_to_vec {
             vec![t]
         }
      };
-    ($f:ident, $sub:expr_2021, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
+    ($f:ident, $sub:expr, $pred:expr_2021, $ob:expr_2021, $($rest:expr_2021),+) => {
         {
             let mut v = triples_to_vec!($f, $sub, $pred, $ob);
             v.extend(triples_to_vec!($f, $($rest),*));

--- a/src/model.rs
+++ b/src/model.rs
@@ -98,7 +98,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/model.rs
+++ b/src/model.rs
@@ -93,7 +93,6 @@ use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
-use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -52,7 +52,7 @@ impl<A: ForIRI> Reanonymize<A> {
 impl<A: ForIRI> VisitMut<A> for Reanonymize<A> {
     fn visit_anonymous_individual(&mut self, ai: &mut AnonymousIndividual<A>) {
         self.count += 1;
-        std::mem::swap(ai, &mut self.b.anon(format!("anon_{}", self.count)))
+        *ai = self.b.anon(format!("anon_{}", self.count))
     }
 }
 

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -15,7 +15,6 @@ use super::set::SetOntology;
 use crate::model::*;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
-    iter::FromIterator,
     ops::Deref,
     rc::Rc,
     sync::Arc,

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -43,7 +43,7 @@ macro_rules! onimpl {
     ($kind:ident, $method:ident) => {
         onimpl!($kind, $method, stringify!($kind));
     };
-    ($kind:ident, $method:ident, $skind:expr) => {
+    ($kind:ident, $method:ident, $skind:expr_2021) => {
         impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
             #[doc = "Return all instances of"]
             #[doc = $skind]
@@ -228,10 +228,10 @@ impl<'a, A: ForIRI, AA: ForIndex<A>> Iterator for ComponentMappedIter<'a, A, AA>
     type Item = &'a AnnotatedComponent<A>;
     fn next(&mut self) -> Option<Self::Item> {
         // Consume the current iterator if there are items left.
-        if let Some(ref mut it) = self.inner {
-            if let Some(component) = it.next() {
-                return Some(component.borrow());
-            }
+        if let Some(ref mut it) = self.inner
+            && let Some(component) = it.next()
+        {
+            return Some(component.borrow());
         }
         // Attempt to consume the iterator for the next component kind
         if !self.kinds.is_empty() {

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -80,7 +80,7 @@ impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
     }
 
     /// Gets an iterator that visits the annotated components of the ontology.
-    pub fn iter(&self) -> ComponentMappedIter<A, AA> {
+    pub fn iter(&self) -> ComponentMappedIter<'_, A, AA> {
         // TODO -- what can't this just use flat_map?
         ComponentMappedIter {
             ont: self,

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -42,7 +42,7 @@ macro_rules! onimpl {
     ($kind:ident, $method:ident) => {
         onimpl!($kind, $method, stringify!($kind));
     };
-    ($kind:ident, $method:ident, $skind:expr_2021) => {
+    ($kind:ident, $method:ident, $skind:expr) => {
         impl<A: ForIRI, AA: ForIndex<A>> ComponentMappedIndex<A, AA> {
             #[doc = "Return all instances of"]
             #[doc = $skind]

--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -1,8 +1,8 @@
 //! An index that provides rapid look up via declaration kind
 
 use crate::model::{
-    AnnotatedComponent, Component, ComponentKind, ForIRI, Kinded, NamedEntityKind,
-    NamedOWLEntityKind, RcAnnotatedComponent, RcStr, IRI,
+    AnnotatedComponent, Component, ComponentKind, ForIRI, IRI, Kinded, NamedEntityKind,
+    NamedOWLEntityKind, RcAnnotatedComponent, RcStr,
 };
 
 use super::indexed::ForIndex;
@@ -88,7 +88,7 @@ impl<A: ForIRI, AA: ForIndex<A>> DeclarationMappedIndex<A, AA> {
 }
 
 macro_rules! some {
-    ($body:expr) => {
+    ($body:expr_2021) => {
         (|| Some($body))()
     };
 }

--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -88,7 +88,7 @@ impl<A: ForIRI, AA: ForIndex<A>> DeclarationMappedIndex<A, AA> {
 }
 
 macro_rules! some {
-    ($body:expr_2021) => {
+    ($body:expr) => {
         (|| Some($body))()
     };
 }

--- a/src/ontology/indexed.rs
+++ b/src/ontology/indexed.rs
@@ -18,7 +18,7 @@
 //! and `ThreeIndexedOntology`, each of which operate something like a
 //! named tuple, allowing differently typed `OntologyIndex` objects to
 //! be added.
-use crate::model::{AnnotatedComponent, ArcStr, ForIRI, MutableOntology, Ontology, RcStr, IRI};
+use crate::model::{AnnotatedComponent, ArcStr, ForIRI, IRI, MutableOntology, Ontology, RcStr};
 use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -253,12 +253,12 @@ pub struct ThreeIndexedOntology<A, AA, I, J, K>(
 );
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-    > ThreeIndexedOntology<A, AA, I, J, K>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+> ThreeIndexedOntology<A, AA, I, J, K>
 {
     pub fn new(i: I, j: J, k: K) -> Self {
         ThreeIndexedOntology(TwoIndexedOntology(
@@ -294,22 +294,22 @@ impl<A, AA, I: Default, J: Default, K: Default> Default for ThreeIndexedOntology
 }
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-    > Ontology<A> for ThreeIndexedOntology<A, AA, I, J, K>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+> Ontology<A> for ThreeIndexedOntology<A, AA, I, J, K>
 {
 }
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-    > MutableOntology<A> for ThreeIndexedOntology<A, AA, I, J, K>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+> MutableOntology<A> for ThreeIndexedOntology<A, AA, I, J, K>
 {
     fn insert<IAA: Into<AnnotatedComponent<A>>>(&mut self, cmp: IAA) -> bool {
         self.0.insert(cmp)
@@ -321,12 +321,12 @@ impl<
 }
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-    > OntologyIndex<A, AA> for ThreeIndexedOntology<A, AA, I, J, K>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+> OntologyIndex<A, AA> for ThreeIndexedOntology<A, AA, I, J, K>
 {
     fn index_insert(&mut self, cmp: AA) -> bool {
         let rtn = (self.0).0.index_insert(cmp.clone());
@@ -348,13 +348,13 @@ pub struct FourIndexedOntology<A, AA, I, J, K, L>(
 );
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-        L: OntologyIndex<A, AA>,
-    > FourIndexedOntology<A, AA, I, J, K, L>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+    L: OntologyIndex<A, AA>,
+> FourIndexedOntology<A, AA, I, J, K, L>
 {
     pub fn new(i: I, j: J, k: K, l: L) -> Self {
         FourIndexedOntology(TwoIndexedOntology(
@@ -396,24 +396,24 @@ impl<A, AA, I: Default, J: Default, K: Default, L: Default> Default
 }
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-        L: OntologyIndex<A, AA>,
-    > Ontology<A> for FourIndexedOntology<A, AA, I, J, K, L>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+    L: OntologyIndex<A, AA>,
+> Ontology<A> for FourIndexedOntology<A, AA, I, J, K, L>
 {
 }
 
 impl<
-        A: ForIRI,
-        AA: ForIndex<A>,
-        I: OntologyIndex<A, AA>,
-        J: OntologyIndex<A, AA>,
-        K: OntologyIndex<A, AA>,
-        L: OntologyIndex<A, AA>,
-    > MutableOntology<A> for FourIndexedOntology<A, AA, I, J, K, L>
+    A: ForIRI,
+    AA: ForIndex<A>,
+    I: OntologyIndex<A, AA>,
+    J: OntologyIndex<A, AA>,
+    K: OntologyIndex<A, AA>,
+    L: OntologyIndex<A, AA>,
+> MutableOntology<A> for FourIndexedOntology<A, AA, I, J, K, L>
 {
     fn insert<IAA: Into<AnnotatedComponent<A>>>(&mut self, cmp: IAA) -> bool {
         self.0.insert(cmp)

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -9,7 +9,7 @@ use super::indexed::ForIndex;
 use super::set::SetOntology;
 use crate::{
     model::*,
-    visitor::immutable::{entity::IRIExtract, Walk},
+    visitor::immutable::{Walk, entity::IRIExtract},
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -88,7 +88,10 @@ impl<A: ForIRI, AA: ForIndex<A>> IRIMappedIndex<A, AA> {
     /// Iterates over the annotated components associated to `iri` by the index.
     ///
     /// Use [`component()`](Self::component) to iterate over components without annotations.
-    pub fn component_for_iri(&self, iri: &IRI<A>) -> impl Iterator<Item = &AnnotatedComponent<A>> {
+    pub fn component_for_iri(
+        &self,
+        iri: &IRI<A>,
+    ) -> impl Iterator<Item = &AnnotatedComponent<A>> + use<'_, A, AA> {
         self.set_for_iri(iri)
             // Iterate over option
             .into_iter()
@@ -100,7 +103,7 @@ impl<A: ForIRI, AA: ForIndex<A>> IRIMappedIndex<A, AA> {
     /// Iterates over the components (without annotations) associated to `iri` by the index.
     ///
     /// Use [`component_for_iri()`](Self::component_for_iri) to iterate over annotated components.
-    pub fn component(&self, iri: &IRI<A>) -> impl Iterator<Item = &Component<A>> {
+    pub fn component(&self, iri: &IRI<A>) -> impl Iterator<Item = &Component<A>> + use<'_, A, AA> {
         self.component_for_iri(iri).map(|ann| &ann.component)
     }
 }
@@ -272,7 +275,7 @@ impl<A: ForIRI, AA: ForIndex<A>> IRIMappedOntology<A, AA> {
     pub fn components_for_iri(
         &mut self,
         iri: &IRI<A>,
-    ) -> impl Iterator<Item = &AnnotatedComponent<A>> {
+    ) -> impl Iterator<Item = &AnnotatedComponent<A>> + use<'_, A, AA> {
         self.0.j().component_for_iri(iri)
     }
 

--- a/src/ontology/logically_equal.rs
+++ b/src/ontology/logically_equal.rs
@@ -4,7 +4,6 @@ use crate::ontology::indexed::ForIndex;
 
 use super::indexed::{OntologyIndex, ThreeIndexedOntology, TwoIndexedOntology};
 use std::collections::HashMap;
-use std::convert::AsRef;
 use std::rc::Rc;
 
 #[derive(Debug)]

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -1,10 +1,5 @@
 //! Rapid, simple, in-memory `Ontology` and `OntologyIndex`
-use std::{
-    collections::HashSet,
-    hash::Hash,
-    iter::{FromIterator, FusedIterator},
-    rc::Rc,
-};
+use std::{collections::HashSet, hash::Hash, iter::FusedIterator, rc::Rc};
 
 use super::indexed::ForIndex;
 use super::indexed::{OneIndexedOntology, OntologyIndex};

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -99,7 +99,7 @@ pub fn localize_iri<A: ForIRI>(iri: &IRI<A>, doc_iri: &IRI<A>) -> IRI<A> {
     b.iri(if let Some(index) = doc_iri.rfind('/') {
         format!("{}/{}", doc_iri.split_at(index).0, term_iri)
     } else {
-        format!("./{}", term_iri)
+        format!("./{term_iri}")
     })
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -9,9 +9,6 @@ use crate::model::{Build, ForIRI, IRI};
 
 use std::path::{Path, PathBuf};
 
-#[cfg(feature = "remote")]
-use ureq;
-
 // fn from_dir_bufread<R: BufRead>(dir: PathBuf, iri:&String) -> R {
 //     // Split the string from the last / (rsplit)
 //     // File in same directory exists?

--- a/src/visitor/mutable.rs
+++ b/src/visitor/mutable.rs
@@ -820,7 +820,7 @@ mod test {
         fn visit_annotation(&mut self, a: &mut Annotation<A>) {
             if a.ap
                 .0
-                 .0
+                .0
                 .as_ref()
                 .eq("http://www.w3.org/2000/01/rdf-schema#label")
             {

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -74,7 +74,7 @@ macro_rules! vocabulary_traits {
 }
 
 macro_rules! vocabulary_type {
-    ($(#[$attr:meta])* $enum_type:ident, $return_type:ty, $storage:ident, [$(($ns:ident, $variant:ident, $first_lowercase:expr_2021)),*]) => {
+    ($(#[$attr:meta])* $enum_type:ident, $return_type:ty, $storage:ident, [$(($ns:ident, $variant:ident, $first_lowercase:expr)),*]) => {
 
         $(#[$attr]) *
         #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -1,8 +1,8 @@
 //! Core RDF vocabularies used in the OWL2 RDF format.
 use enum_meta::*;
 
-use crate::error::invalid;
 use crate::error::HornedError;
+use crate::error::invalid;
 use crate::model::Build;
 use crate::model::ForIRI;
 use crate::model::IRI;
@@ -75,7 +75,7 @@ macro_rules! vocabulary_traits {
 }
 
 macro_rules! vocabulary_type {
-    ($(#[$attr:meta])* $enum_type:ident, $return_type:ty, $storage:ident, [$(($ns:ident, $variant:ident, $first_lowercase:expr)),*]) => {
+    ($(#[$attr:meta])* $enum_type:ident, $return_type:ty, $storage:ident, [$(($ns:ident, $variant:ident, $first_lowercase:expr_2021)),*]) => {
 
         $(#[$attr]) *
         #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -850,36 +850,44 @@ mod tests {
     pub fn test_entity_for_iri() {
         let b = Build::new_rc();
 
-        assert!(entity_for_iri(
-            "http://www.w3.org/2002/07/owl#Class",
-            "http://www.example.com",
-            &b
-        )
-        .is_ok());
-        assert!(entity_for_iri(
-            "http://www.w3.org/2002/07/owl#Fred",
-            "http://www.example.com",
-            &b
-        )
-        .is_err());
+        assert!(
+            entity_for_iri(
+                "http://www.w3.org/2002/07/owl#Class",
+                "http://www.example.com",
+                &b
+            )
+            .is_ok()
+        );
+        assert!(
+            entity_for_iri(
+                "http://www.w3.org/2002/07/owl#Fred",
+                "http://www.example.com",
+                &b
+            )
+            .is_err()
+        );
     }
 
     #[test]
     pub fn test_namespace_in_entity_for_iri() {
         let b = Build::new_rc();
 
-        assert!(entity_for_iri(
-            "http://www.w3.org/2002/07/low#Class",
-            "http://www.example.com",
-            &b
-        )
-        .is_err());
-        assert!(entity_for_iri(
-            "abcdefghijklmnopqrstuvwxyz123#Class",
-            "http://www.example.com",
-            &b
-        )
-        .is_err());
+        assert!(
+            entity_for_iri(
+                "http://www.w3.org/2002/07/low#Class",
+                "http://www.example.com",
+                &b
+            )
+            .is_err()
+        );
+        assert!(
+            entity_for_iri(
+                "abcdefghijklmnopqrstuvwxyz123#Class",
+                "http://www.example.com",
+                &b
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -9,7 +9,6 @@ use crate::model::IRI;
 use crate::model::{NamedOWLEntity, NamedOWLEntityKind};
 
 use std::borrow::Borrow;
-use std::convert::TryFrom;
 use std::str::FromStr;
 use std::sync::OnceLock;
 

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -898,11 +898,9 @@ mod tests {
         ));
         // ...and `String`s.
         assert!(is_annotation_builtin(
-            "http://www.w3.org/2000/01/rdf-schema#comment".to_string()
+            "http://www.w3.org/2000/01/rdf-schema#comment"
         ));
-        assert!(!is_annotation_builtin(
-            "http://www.w3.org/2002/07/owl#fred".to_string()
-        ));
+        assert!(!is_annotation_builtin("http://www.w3.org/2002/07/owl#fred"));
     }
 
     #[test]


### PR DESCRIPTION
I used `cargo fix --edition` and then upgraded the "edition" field in `Cargo.toml` and `horned-bin/Cargo.toml` to upgrade from 2018 to 2021 edition and then repeated the process to upgrade from 2021 to 2024. This PR resolves issue #155.