### PR TITLE
Removing A: ForIRI from Build<A>.

### DIFF
--- a/benches/model.rs
+++ b/benches/model.rs
@@ -237,8 +237,8 @@ fn food_to_vec() -> Vec<u8> {
     std::fs::read("./benches/ont/food.owl").unwrap()
 }
 
-fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &Vec<u8>, b: Build<A>) -> ConcreteRDFOntology<A, AA> {
-    let mut c = Cursor::new(v.clone());
+fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &[u8], b: Build<A>) -> ConcreteRDFOntology<A, AA> {
+    let mut c = Cursor::new(v);
     horned_owl::io::rdf::reader::read_with_build(&mut c, &b, Default::default())
         .unwrap()
         .0
@@ -252,21 +252,21 @@ fn food(c: &mut Criterion) {
 
     group.bench_function("food_rc_str_rc_comp", |b| {
         b.iter(|| {
-            let b: Build<RcStr> = Build::new();
+            let b: Build<RcStr> = Build::default();
             let _: ConcreteRDFOntology<RcStr, RcAnnotatedComponent> = read_vec(&food, b);
         })
     });
 
     group.bench_function("food_arc_str_arc_comp", |b| {
         b.iter(|| {
-            let b: Build<ArcStr> = Build::new();
+            let b: Build<ArcStr> = Build::default();
             let _: ConcreteRDFOntology<ArcStr, ArcAnnotatedComponent> = read_vec(&food, b);
         })
     });
 
     group.bench_function("food_string_direct_comp", |b| {
         b.iter(|| {
-            let b: Build<String> = Build::new();
+            let b: Build<String> = Build::default();
             let _: ConcreteRDFOntology<String, AnnotatedComponent<String>> = read_vec(&food, b);
         })
     });

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -66,7 +66,7 @@ pub fn parse_path(
             ParserOutput::owx(horned_owl::io::owx::reader::read(&mut bufreader, config)?)
         }
         Some(ResourceType::RDF) => {
-            let b = Build::new();
+            let b = Build::default();
             let iri = horned_owl::resolve::path_to_file_iri(&b, path);
             ParserOutput::rdf(horned_owl::io::rdf::closure_reader::read(&iri, config)?)
         }
@@ -93,7 +93,7 @@ pub fn parse_imports(
             ParserOutput::owx(horned_owl::io::owx::reader::read(&mut bufreader, config)?)
         }
         Some(ResourceType::RDF) => {
-            let b = Build::new();
+            let b = Build::default();
             let mut p = horned_owl::io::rdf::reader::parser_with_build(&mut bufreader, &b, config);
             p.parse_imports()?;
             ParserOutput::rdf(p.as_ontology_and_incomplete())
@@ -111,7 +111,7 @@ pub fn materialize(
     config: ParserConfiguration,
 ) -> Result<Vec<IRI<RcStr>>, HornedError> {
     let mut v = vec![];
-    let b = Build::new();
+    let b = Build::default();
 
     // We need to determine at this point whether we have an IRI or a file location, already.
     let parsed = oxiri::Iri::parse(file_or_iri);

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -992,7 +992,7 @@ mod test {
     #[test]
     fn test_ont_rt() {
         let mut ont = ComponentMappedOntology::new_rc();
-        let build = Build::new();
+        let build = Build::default();
 
         let iri = build.iri("http://www.example.com/a".to_string());
         ont.insert(OntologyID {

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -1786,7 +1786,7 @@ mod test {
     #[test]
     fn test_ont_rt() {
         let mut ont = ComponentMappedOntology::new_rc();
-        let build = Build::new();
+        let build = Build::default();
 
         let iri = build.iri("http://www.example.com/a".to_string());
         ont.insert(OntologyID {

--- a/src/model.rs
+++ b/src/model.rs
@@ -268,7 +268,7 @@ impl<A: ForIRI> IRI<A> {
 /// different instances can be combined within a single ontology
 /// without consequences except for increased memory use.
 #[derive(Debug, Default)]
-pub struct Build<A: ForIRI>(
+pub struct Build<A>(
     RefCell<BTreeSet<IRI<A>>>,
     RefCell<BTreeSet<AnonymousIndividual<A>>>,
 );

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -448,7 +448,7 @@ mod test {
     #[test]
     fn test_ontology_into_iter() {
         // Setup
-        let build = Build::new();
+        let build = Build::default();
         let mut o = ComponentMappedOntology::new_rc();
         let decl1 = DeclareClass(build.class("http://www.example.com#a"));
         let decl2 = DeclareClass(build.class("http://www.example.com#b"));

--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -220,7 +220,7 @@ mod test {
         assert!(d.index_insert(s.1.into()));
         assert!(d.index_insert(s.2.into()));
 
-        let b = Build::new();
+        let b = Build::default();
         assert_eq!(
             d.declaration_kind(&b.iri("http://www.example.com/c")),
             Some(NamedOWLEntityKind::Class)

--- a/src/visitor/mutable.rs
+++ b/src/visitor/mutable.rs
@@ -109,6 +109,7 @@ pub trait VisitMut<A: ForIRI> {
     fn visit_darg_vec(&mut self, _: &mut Vec<DArgument<A>>) {}
 }
 
+#[derive(Default)]
 pub struct WalkMut<A, V>(V, PhantomData<A>);
 
 impl<A: ForIRI, V: VisitMut<A>> WalkMut<A, V> {
@@ -809,12 +810,12 @@ impl<A: ForIRI, V: VisitMut<A>> WalkMut<A, V> {
 }
 
 #[cfg(test)]
-
 mod test {
     use super::*;
     use crate::io::owx::reader::test::read_ok;
     use crate::model::Build;
 
+    #[derive(Default)]
     struct LabeltoFred;
     impl<A: ForIRI> VisitMut<A> for LabeltoFred {
         fn visit_annotation(&mut self, a: &mut Annotation<A>) {
@@ -859,12 +860,13 @@ mod test {
                 assert_eq!(literal, &"fred".to_string());
             }
             _ => {
-                assert!(false);
+                unreachable!();
             }
         }
     }
 
-    struct AddAnnotation<A: ForIRI>(Build<A>);
+    #[derive(Default)]
+    struct AddAnnotation<A>(Build<A>);
     impl<A: ForIRI> VisitMut<A> for AddAnnotation<A> {
         fn visit_annotation_vec(&mut self, a: &mut Vec<Annotation<A>>) {
             a.push(Annotation {
@@ -882,9 +884,7 @@ mod test {
         let ont_s = include_str!("../ont/owl-xml/class.owx");
         let (ont, _) = read_ok(&mut ont_s.as_bytes());
 
-        dbg!(&ont.i().declare_class().next());
-
-        let mut walk = super::WalkMut::new(AddAnnotation(Build::new()));
+        let mut walk: super::WalkMut<_, AddAnnotation<_>> = super::WalkMut::default();
         let mut vec: Vec<_> = ont.into_iter().collect();
         assert_eq!(vec[0].ann.len(), 0);
 


### PR DESCRIPTION
Resolves #74.

Additionally:

- fixes some clippy warnings
- goes from Build::new() to Build::default() where possible

@phillord I can merge this myself unless there are objections.