### PR TITLE
fix(io/ofn): three literal/individual round-trip bugs (multi-byte escape, script langtags, blank-node prefix)

### DIFF
--- a/src/grammars/bcp47.pest
+++ b/src/grammars/bcp47.pest
@@ -12,7 +12,11 @@ BCP47_Language = ${
   | ASCII_ALPHA{5}
 }
 
-BCP47_ExtLang       = ${ ASCII_ALPHA{3} ~ ("-" ~ ASCII_ALPHA{3}){,2} }
+// Each extlang subtag is exactly 3 alpha. Without the `!ASCII_ALPHA` guards a
+// greedy PEG match would consume the first 3 letters of a following 4-alpha
+// script subtag (e.g. `zh-Hans` -> `zh` + extlang `Han`, stranding `s`); the
+// guards force extlang to yield so the script subtag can match.
+BCP47_ExtLang       = ${ ASCII_ALPHA{3} ~ !ASCII_ALPHA ~ ("-" ~ ASCII_ALPHA{3} ~ !ASCII_ALPHA){,2} }
 BCP47_Script        = ${ ASCII_ALPHA{4} }
 BCP47_Region        = ${ ASCII_ALPHA{2} | ASCII_DIGIT{3} }
 BCP47_Variant       = ${ ASCII_ALPHANUMERIC{5, 8} | ASCII_DIGIT ~ ASCII_ALPHANUMERIC{3} }

--- a/src/io/ofn/reader/from_pair.rs
+++ b/src/io/ofn/reader/from_pair.rs
@@ -1146,6 +1146,50 @@ mod tests {
     }
 
     #[test]
+    fn language_tag_with_script_subtag() {
+        let build = Build::default();
+        let prefixes = PrefixMapping::default();
+
+        // Region subtags already parse; script subtags (4 alpha following a
+        // 2-3 alpha primary language) must not be swallowed by ExtLang.
+        assert_parse_into!(
+            Literal<String>,
+            Rule::Literal,
+            build,
+            prefixes,
+            r#""街道"@zh-Hans"#,
+            Literal::Language {
+                literal: String::from("街道"),
+                lang: String::from("zh-Hans"),
+            }
+        );
+
+        assert_parse_into!(
+            Literal<String>,
+            Rule::Literal,
+            build,
+            prefixes,
+            r#""grad"@sr-Latn"#,
+            Literal::Language {
+                literal: String::from("grad"),
+                lang: String::from("sr-Latn"),
+            }
+        );
+
+        assert_parse_into!(
+            Literal<String>,
+            Rule::Literal,
+            build,
+            prefixes,
+            r#""color"@en-US"#,
+            Literal::Language {
+                literal: String::from("color"),
+                lang: String::from("en-US"),
+            }
+        );
+    }
+
+    #[test]
     fn has_key() {
         let build = Build::default();
         let mut prefixes = PrefixMapping::default();

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -13,7 +13,10 @@ use crate::vocab::Facet;
 /// Write a string literal while escaping `"` and `\` characters.
 fn quote(mut s: &str, f: &mut Formatter<'_>) -> Result<(), Error> {
     f.write_str("\"")?;
-    while let Some((i, c)) = s.chars().enumerate().find(|(_, c)| *c == '\\' || *c == '"') {
+    // `char_indices` yields byte offsets so the slices below land on char
+    // boundaries even when earlier characters are multi-byte. `'"'` and `'\\'`
+    // are both single-byte ASCII, so `i + 1` is always a valid boundary too.
+    while let Some((i, c)) = s.char_indices().find(|(_, c)| *c == '\\' || *c == '"') {
         f.write_str(&s[..i])?;
         match c {
             '\\' => f.write_str("\\\\")?,
@@ -1101,6 +1104,24 @@ mod tests {
         };
         let ofn = format!("{}", lit.as_functional());
         assert_eq!(r#""test\\""#, &ofn);
+    }
+
+    #[test]
+    fn test_ofn_literal_multibyte_escape() {
+        // A multi-byte character preceding an escaped `"` or `\` must not cause
+        // a byte-vs-char index mismatch while slicing (regression: panicked at
+        // a non-char boundary, e.g. inside `é` or a combining mark).
+        let lit = Literal::<String>::Simple {
+            literal: String::from("café\""),
+        };
+        let ofn = format!("{}", lit.as_functional());
+        assert_eq!(r#""café\"""#, &ofn);
+
+        let lit = Literal::<String>::Simple {
+            literal: String::from("素面\\x"),
+        };
+        let ofn = format!("{}", lit.as_functional());
+        assert_eq!(r#""素面\\x""#, &ofn);
     }
 
     #[test]

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -464,7 +464,16 @@ impl<A: ForIRI> AsFunctional<A> for AnnotationValue<A> {}
 
 impl<A: ForIRI> Display for Functional<'_, AnonymousIndividual<A>, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(f, "{}", self.0.0.borrow())
+        // Functional syntax requires the `_:` blank-node prefix. Generated
+        // labels (e.g. from the RDF reader) are bare, while labels parsed from
+        // functional/Manchester input already carry it, so add it only when
+        // absent to avoid double-prefixing.
+        let label = self.0.0.borrow();
+        if label.starts_with("_:") {
+            write!(f, "{}", label)
+        } else {
+            write!(f, "_:{}", label)
+        }
     }
 }
 
@@ -1122,6 +1131,22 @@ mod tests {
         };
         let ofn = format!("{}", lit.as_functional());
         assert_eq!(r#""素面\\x""#, &ofn);
+    }
+
+    #[test]
+    fn test_ofn_anonymous_individual_nodeid() {
+        let build = Build::new_arc();
+
+        // Generated anonymous individuals (e.g. from the RDF reader, via
+        // `anon_renumbered`) hold a BARE label; functional syntax requires the
+        // `_:` blank-node prefix, so it must be added.
+        let anon = build.anon("anon000007");
+        assert_eq!("_:anon000007", format!("{}", anon.as_functional()));
+
+        // A label that already carries `_:` (e.g. parsed from functional/
+        // Manchester input) must not be double-prefixed.
+        let anon = build.anon("_:x1");
+        assert_eq!("_:x1", format!("{}", anon.as_functional()));
     }
 
     #[test]


### PR DESCRIPTION
*(Claude Code here, working on Michel's fork; he reviewed before this went up.)*

Three independent bugs in the functional-syntax reader/writer on `devel`, all surfaced by round-tripping a large real-world OWL corpus (BioPortal). Each is small and has a regression test.

**1. `quote()` panics on multi-byte string literals** (`io/ofn/writer/as_functional.rs`)

The escaper found the next `"`/`\` with `chars().enumerate()` (a *character* index) but sliced with `&s[..i]` (a *byte* index). Any literal with a multi-byte character before an escaped `"` or `\` sliced inside a UTF-8 sequence and panicked (`byte index N is not a char boundary`). Fixed by using `char_indices()`; the matched delimiters are single-byte ASCII, so `i + 1` stays a valid boundary.

**2. Language tags with a script subtag fail to parse** (`grammars/bcp47.pest`)

`BCP47_ExtLang` (exactly 3 alpha) greedily consumed the first 3 letters of a following 4-alpha script subtag: `zh-Hans` parsed as `zh` + extlang `Han`, stranding `s`, so the enclosing literal failed. Region subtags (`en-US`) were unaffected. Added `!ASCII_ALPHA` guards so an extlang subtag yields when a fourth letter follows, letting the script subtag match. `zh-Hans` / `sr-Latn` now parse; extlang tags such as `zh-yue` still work.

**3. Anonymous individuals are written without the `_:` prefix** (`io/ofn/writer/as_functional.rs`)

`AnonymousIndividual` was written using its raw stored label. Labels parsed from functional/Manchester input keep the `_:` prefix (the grammar's `SPARQL_BlankNodeLabel` includes it), but generated labels — e.g. the RDF reader's `anon_renumbered` (`anon000007`) — are bare, so the writer emitted `anon000007`, which is not a valid `NodeID` and fails to re-parse. Add the `_:` prefix when absent, leaving already-prefixed labels untouched.

Full lib suite green (950), including three new targeted tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JttPNg3CYQnjuZ1r3Vur1
