### PR TITLE
fix(io/omn): render SWRL built-in atom predicates as full IRIs (#187)

### DIFF
--- a/dev/reparse-all.clj
+++ b/dev/reparse-all.clj
@@ -47,16 +47,17 @@
 ;;   `Class: Annotations: ... o:C` (annotation before the frame subject
 ;;   IRI), which OWL API's parser also rejects (it expects the IRI
 ;;   immediately after the frame keyword).
-;; - swrl_built_in.omn / swrl_data_range.omn: our `Rule:` frame renders
-;;   built-in and data-range SWRL atoms with a generic `iri(args...)` call
-;;   syntax, which OWL API's Manchester `Rule:` grammar does not accept
-;;   for those atom kinds.
+;; - swrl_data_range.omn: the data-range SWRL atom has a *literal* argument
+;;   (`xsd:integer("literal1")`), but OWL API's Manchester `Rule:` grammar
+;;   only accepts a variable (`?x`) there, so the reference parser rejects it.
+;;   (swrl_built_in.omn is no longer excluded: our writer now renders a
+;;   built-in atom's predicate as a full `<IRI>` rather than a CURIE, which
+;;   OWL API accepts.)
 (def known-parser-limitations
   ["anon-subobjectproperty.omn"
    "declaration-with-annotation.omn"
    "declaration-with-two-annotation.omn"
    "inverse-transitive.omn"
-   "swrl_built_in.omn"
    "swrl_data_range.omn"
    "swrl_individual.ofn"
    "swrl_individual.omn"

--- a/src/io/omn/writer/as_manchester.rs
+++ b/src/io/omn/writer/as_manchester.rs
@@ -597,7 +597,13 @@ impl<A: ForIRI> Display for Manchester<'_, Atom<A>, A> {
                 write!(f, "{}({}, {})", m!(pred), m!(&args.0), m!(&args.1))
             }
             Atom::BuiltInAtom { pred, args } => {
-                write!(f, "{}(", m!(pred))?;
+                // OWL API's Manchester `Rule:` grammar accepts a prefixed name
+                // only for a *known* swrlb built-in; an arbitrary built-in IRI is
+                // rejected as a CURIE (e.g. `o:y(...)`) and must be written in
+                // full `<IRI>` form. Render the predicate with no prefix mapping
+                // so it is always the full IRI, which the reference parser also
+                // accepts for the standard swrlb built-ins.
+                write!(f, "{}(", Manchester(pred, None, PhantomData::<A>))?;
                 for (i, a) in args.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;


### PR DESCRIPTION
*(Claude Code here, on Michel's fork; he reviewed before this went up.)*

Fixes one of the `reparse_omn` exclusions from #187.

The Manchester writer rendered a SWRL `BuiltInAtom` predicate through the prefix mapping, so a custom built-in came out as a CURIE (e.g. `o:y(...)`). OWL API's `ManchesterOWLSyntaxOntologyParser` accepts a prefixed name only for a *known* `swrlb:` built-in — an arbitrary built-in IRI as a CURIE is rejected. Rendering the predicate as a full `<IRI>` makes the reference parser accept it (and it's also accepted for the standard `swrlb:` built-ins), so `swrl_built_in.omn` reparses.

Verified with the reference parser (bubo / `ManchesterOWLSyntaxOntologyParser`): the rewritten fixture parses, still round-trips through our own reader, and the full lib suite (1288) passes. `swrl_built_in.omn` is dropped from the `reparse-all.clj` exclusions.

The other six #187 exclusions are genuinely inexpressible in OWL-API Manchester, so they stay — including `swrl_data_range.omn`, which is a *different* root cause (its data-range atom has a literal argument, but the `Rule:` grammar accepts only a variable there); I split that out in the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JttPNg3CYQnjuZ1r3Vur1
