### PR TITLE
Replace test-generator with rstest for file-based parameterised tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ criterion = "0.7.0"
 mktemp = "0.5.1"
 pretty_assertions = "1.0.0"
 slurp = "1.0.1"
-test-generator =  { version = "^0.3" }
+rstest = "0.23"
 horned-bin = {path="horned-bin"}
 
 [profile.release]

--- a/src/io/ofn/reader/from_pair.rs
+++ b/src/io/ofn/reader/from_pair.rs
@@ -1124,7 +1124,8 @@ mod tests {
     use crate::io::ofn::reader::lexer::OwlFunctionalLexer;
     use crate::ontology::set::SetOntology;
 
-    use test_generator::test_resources;
+    use rstest::rstest;
+    use std::path::PathBuf;
 
     macro_rules! assert_parse_into {
         ($ty:ty, $rule:path, $build:ident, $prefixes:ident, $doc:expr, $expected:expr_2021) => {
@@ -1328,9 +1329,9 @@ mod tests {
         pretty_assertions::assert_eq!(actual, expected);
     }
 
-    #[test_resources("src/ont/owl-functional/*.ofn")]
-    fn from_pair_resource(resource: &str) {
-        let text = &slurp::read_all_to_string(resource).unwrap();
+    #[rstest]
+    fn from_pair_resource(#[files("src/ont/owl-functional/*.ofn")] resource: PathBuf) {
+        let text = &slurp::read_all_to_string(&resource).unwrap();
         let pair = match OwlFunctionalLexer::lex(Rule::OntologyDocument, text.trim()) {
             Err(e) => panic!("parser failed: {e}"),
             Ok(mut pairs) => {
@@ -1347,6 +1348,8 @@ mod tests {
             FromPair::from_pair(pair, &ctx).unwrap();
 
         let path = resource
+            .to_str()
+            .unwrap()
             .replace("owl-functional", "owl-xml")
             .replace(".ofn", ".owx");
         let owx = &slurp::read_all_to_string(path).unwrap();

--- a/src/io/ofn/reader/lexer.rs
+++ b/src/io/ofn/reader/lexer.rs
@@ -29,11 +29,12 @@ impl OwlFunctionalLexer {
 pub mod test {
     use super::*;
 
-    use test_generator::test_resources;
+    use rstest::rstest;
+    use std::path::PathBuf;
 
-    #[test_resources("src/ont/owl-functional/*.ofn")]
-    fn lex_resource(resource: &str) {
-        let ont_s = slurp::read_all_to_string(resource).unwrap();
+    #[rstest]
+    fn lex_resource(#[files("src/ont/owl-functional/*.ofn")] resource: PathBuf) {
+        let ont_s = slurp::read_all_to_string(&resource).unwrap();
         match OwlFunctionalLexer::lex(Rule::OntologyDocument, ont_s.trim()) {
             Ok(mut pairs) => assert_eq!(pairs.next().unwrap().as_str(), ont_s.trim()),
             Err(e) => panic!("parser failed: {e}"),

--- a/src/io/ofn/writer/mod.rs
+++ b/src/io/ofn/writer/mod.rs
@@ -99,11 +99,12 @@ mod test {
     use crate::model::RcStr;
 
     use pretty_assertions::assert_eq;
-    use test_generator::test_resources;
+    use rstest::rstest;
+    use std::path::PathBuf;
 
-    #[test_resources("src/ont/owl-functional/*.ofn")]
-    fn roundtrip_resource(resource: &str) {
-        let reader = std::fs::File::open(resource)
+    #[rstest]
+    fn roundtrip_resource(#[files("src/ont/owl-functional/*.ofn")] resource: PathBuf) {
+        let reader = std::fs::File::open(&resource)
             .map(std::io::BufReader::new)
             .unwrap();
         let (ont, prefixes): (ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>, _) =

--- a/src/io/omn/reader/from_pair.rs
+++ b/src/io/omn/reader/from_pair.rs
@@ -2309,7 +2309,7 @@ mod tests {
     use super::*;
     use crate::io::omn::reader::lexer::ManchesterLexer;
     use crate::model::{Build, RcStr};
-    use test_generator::test_resources;
+    use rstest::rstest;
 
     #[test]
     fn parses_iri_full_and_prefixed() {
@@ -4947,14 +4947,14 @@ DisjointClasses: ex:r some ex:A, ex:r some ex:B
     /// 122 of the 127 OMN fixtures have an OWX twin (the 5 OMN-only fixtures are
     /// skipped). A further [`COMPARE_EXCLUSIONS`] set covers fixtures whose two
     /// serialisations encode genuinely different ontologies; see that constant.
-    #[test_resources("src/ont/owl-manchester/*.omn")]
-    fn compare_to_owx(resource: &str) {
+    #[rstest]
+    fn compare_to_owx(#[files("src/ont/owl-manchester/*.omn")] resource: std::path::PathBuf) {
         use crate::model::{ComponentKind, Kinded};
         use crate::normalize::normalize;
         use crate::ontology::set::SetOntology;
         use std::path::Path;
 
-        let stem = Path::new(resource)
+        let stem = Path::new(&resource)
             .file_stem()
             .unwrap()
             .to_string_lossy()
@@ -5020,12 +5020,12 @@ DisjointClasses: ex:r some ex:A, ex:r some ex:B
             };
 
         // Read the Manchester form through the OMN reader (the subject).
-        let omn_reader = std::fs::File::open(resource)
+        let omn_reader = std::fs::File::open(&resource)
             .map(std::io::BufReader::new)
             .unwrap();
         let (omn_ont, _): (SetOntology<RcStr>, _) =
             crate::io::omn::reader::read(omn_reader, Default::default())
-                .unwrap_or_else(|e| panic!("OMN read failed for {resource}: {e:?}"));
+                .unwrap_or_else(|e| panic!("OMN read failed for {}: {e:?}", resource.display()));
 
         // Read the OWL/XML form through the OWX reader (the oracle).
         let owx_src = std::fs::read_to_string(&owx_path).unwrap();

--- a/src/io/omn/writer/mod.rs
+++ b/src/io/omn/writer/mod.rs
@@ -1057,7 +1057,8 @@ mod tests {
     use crate::model::*;
     use crate::ontology::component_mapped::ComponentMappedOntology;
     use crate::ontology::set::SetOntology;
-    use test_generator::test_resources;
+    use rstest::rstest;
+    use std::path::PathBuf;
 
     type TestOnt = ComponentMappedOntology<
         std::rc::Rc<str>,
@@ -1075,9 +1076,9 @@ mod tests {
     // SWRL rules, inverse-headed property frames, annotated declarations and
     // anonymous-subject annotation assertions included — so there is no
     // `nonround` bucket.
-    #[test_resources("src/ont/owl-manchester/*.omn")]
-    fn roundtrip_resource(resource: &str) {
-        let reader = std::fs::File::open(resource)
+    #[rstest]
+    fn roundtrip_resource(#[files("src/ont/owl-manchester/*.omn")] resource: PathBuf) {
+        let reader = std::fs::File::open(&resource)
             .map(std::io::BufReader::new)
             .unwrap();
         let (ont, prefixes): (ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>, _) =

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -980,7 +980,8 @@ mod test {
     use std::io::BufReader;
     use std::io::BufWriter;
 
-    use test_generator::test_resources;
+    use rstest::rstest;
+    use std::path::PathBuf;
 
     fn read_ok<R: BufRead>(bufread: &mut R) -> (RcComponentMappedOntology, PrefixMapping) {
         let r = read(bufread, ParserConfiguration::default());
@@ -1108,9 +1109,9 @@ mod test {
         assert_eq!(prefix_orig_map, prefix_round_map);
     }
 
-    #[test_resources("src/ont/owl-xml/*.owx")]
-    fn roundtrip_resource(resource: &str) {
-        let resource = &slurp::read_all_to_string(resource).unwrap();
+    #[rstest]
+    fn roundtrip_resource(#[files("src/ont/owl-xml/*.owx")] resource: PathBuf) {
+        let resource = &slurp::read_all_to_string(&resource).unwrap();
 
         let (ont_orig, _prefix_orig, ont_round, _prefix_round) = roundtrip(resource);
 
@@ -1119,9 +1120,9 @@ mod test {
         assert_eq!(ont_orig, ont_round);
     }
 
-    #[test_resources("src/ont/owl-xml/ambiguous/*.owx")]
-    fn roundtrip_nonround_resource(resource: &str) {
-        let resource = &slurp::read_all_to_string(resource).unwrap();
+    #[rstest]
+    fn roundtrip_nonround_resource(#[files("src/ont/owl-xml/ambiguous/*.owx")] resource: PathBuf) {
+        let resource = &slurp::read_all_to_string(&resource).unwrap();
         assert_round(resource);
     }
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -2581,7 +2581,7 @@ mod test {
     use crate::normalize::normalize;
     use crate::ontology::component_mapped::RcComponentMappedOntology;
     use pretty_assertions::assert_eq;
-    use test_generator::test_resources;
+    use rstest::rstest;
 
     fn read_ok<R: BufRead>(
         bufread: &mut R,
@@ -2596,14 +2596,6 @@ mod test {
         dbg!(&ont, &incomp);
         assert!(incomp.is_complete());
         ont
-    }
-
-    fn compare(test: &str) {
-        let dot = test.rfind('.').unwrap();
-        let slash = test.rfind('/').unwrap();
-        let stem = &test[(slash + 1)..dot];
-
-        compare_two(stem, stem);
     }
 
     fn compare_two(testrdf: &str, testowl: &str) {
@@ -2653,15 +2645,15 @@ mod test {
     //     assert!(true);
     // }
 
-    #[test_resources("src/ont/owl-rdf/*.owl")]
-    fn compare_to_xml(resource: &str) {
-        compare(resource)
+    #[rstest]
+    fn compare_to_xml(#[files("src/ont/owl-rdf/*.owl")] resource: PathBuf) {
+        let stem = resource.file_stem().unwrap().to_str().unwrap();
+        compare_two(stem, stem);
     }
 
-    #[test_resources("src/ont/owl-rdf/ambiguous/*.owl")]
-    fn test_read_ok(resource: &str) {
-        let resource = &slurp::read_all_to_string(resource).unwrap();
-
+    #[rstest]
+    fn test_read_ok(#[files("src/ont/owl-rdf/ambiguous/*.owl")] resource: PathBuf) {
+        let resource = &slurp::read_all_to_string(&resource).unwrap();
         read_ok(&mut resource.as_bytes());
     }
 

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -1779,7 +1779,8 @@ mod test {
 
     use oxrdfio::RdfSerializer;
     use pretty_rdf::ox::WriterQuadSerializerAdaptor;
-    use test_generator::test_resources;
+    use rstest::rstest;
+    use std::path::PathBuf;
     // use std::collections::HashMap;
 
     // use std::fs::File;
@@ -1862,10 +1863,15 @@ mod test {
         (ont_orig, ont_round)
     }
 
-    #[test_resources("src/ont/owl-rdf/*owl")]
-    #[test_resources("src/ont/owl-rdf/ambiguous/*.owl")]
-    fn roundtrip_rdf(resource: &str) {
-        let resource = &slurp::read_all_to_string(resource).unwrap();
+    #[rstest]
+    fn roundtrip_rdf(#[files("src/ont/owl-rdf/*.owl")] resource: PathBuf) {
+        let resource = &slurp::read_all_to_string(&resource).unwrap();
+        assert_round(resource);
+    }
+
+    #[rstest]
+    fn roundtrip_rdf_ambiguous(#[files("src/ont/owl-rdf/ambiguous/*.owl")] resource: PathBuf) {
+        let resource = &slurp::read_all_to_string(&resource).unwrap();
         assert_round(resource);
     }
 


### PR DESCRIPTION
## Summary
- Replace the unmaintained `test-generator` crate with `rstest` for all file-glob parameterised tests (`owx`, `rdf`, `ofn`, `omn` readers/writers).
- `#[test_resources("glob")]` functions become `#[rstest] fn f(#[files("glob")] resource: PathBuf)`; functions with multiple stacked globs are split one-per-function.
- Drop the now-unused `compare` helper in `src/io/rdf/reader.rs` left dead by the conversion.

Closes #180

## Test plan
- [x] `cargo test --lib --bins --tests -- --skip integration` passes (1292 tests)
- [x] `cargo fmt --check` / `cargo clippy` clean
- [x] No remaining `test_generator`/`test-generator` references in source or `Cargo.toml`