### PR TITLE
Add a horned-convert CLI tool for cross-format conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ default-members=[".", "horned-bin"]
 
 [workspace.dependencies]
 indexmap="1.0.2"
+mktemp="0.5.1"
 oxiri="0.2.11"
 ##pretty_rdf={path="./pretty_rdf"}
 pretty_rdf="0.12.0"
@@ -51,7 +52,7 @@ encoding = ["quick-xml/encoding"]
 proptest = "1"
 horned-owl = {path=".", features = ["remote"]}
 criterion = "0.7.0"
-mktemp = "0.5.1"
+mktemp = {workspace = true}
 pretty_assertions = "1.0.0"
 slurp = "1.0.1"
 rstest = "0.23"

--- a/horned-bin/Cargo.toml
+++ b/horned-bin/Cargo.toml
@@ -25,6 +25,7 @@ oxrdfio={workspace=true}
 
 [dev-dependencies]
 assert_cmd = "2.1.1"
+mktemp = {workspace = true}
 predicates = "2.1.0"
 
 
@@ -39,6 +40,10 @@ path = "src/bin/horned_big.rs"
 [[bin]]
 name = "horned-compare"
 path = "src/bin/horned_compare.rs"
+
+[[bin]]
+name = "horned-convert"
+path = "src/bin/horned_convert.rs"
 
 [[bin]]
 name = "horned-dump"

--- a/horned-bin/src/bin/horned.rs
+++ b/horned-bin/src/bin/horned.rs
@@ -5,6 +5,7 @@ use horned_owl::error::HornedError;
 
 mod horned_big;
 mod horned_compare;
+mod horned_convert;
 mod horned_dump;
 mod horned_materialize;
 mod horned_parse;
@@ -28,6 +29,7 @@ fn app() -> App<'static> {
         .arg_required_else_help(true)
         .subcommand(horned_big::app("big"))
         .subcommand(horned_compare::app("compare"))
+        .subcommand(horned_convert::app("convert"))
         .subcommand(horned_dump::app("dump"))
         .subcommand(horned_materialize::app("materialize"))
         .subcommand(horned_parse::app("parse"))
@@ -43,6 +45,7 @@ fn matcher(matches: ArgMatches) -> Result<(), HornedError> {
         match name {
             "big" => horned_big::matcher(submatches),
             "compare" => horned_compare::matcher(submatches),
+            "convert" => horned_convert::matcher(submatches),
             "dump" => horned_dump::matcher(submatches),
             "materialize" => horned_materialize::matcher(submatches),
             "parse" => horned_parse::matcher(submatches),

--- a/horned-bin/src/bin/horned_convert.rs
+++ b/horned-bin/src/bin/horned_convert.rs
@@ -1,0 +1,74 @@
+extern crate clap;
+extern crate horned_owl;
+
+use clap::App;
+use clap::Arg;
+use clap::ArgMatches;
+
+use horned_bin::{
+    config::{parser_app, parser_config},
+    parse_path, write,
+};
+
+use horned_owl::error::HornedError;
+use horned_owl::ontology::component_mapped::RcComponentMappedOntology;
+
+use std::{fs::File, io::stdout, path::Path};
+
+#[allow(dead_code)]
+fn main() -> Result<(), HornedError> {
+    let matches = app("horned-convert").get_matches();
+    matcher(&matches)
+}
+
+pub(crate) fn app(name: &str) -> App<'static> {
+    parser_app(
+        App::new(name)
+            .version("0.1")
+            .about("Convert an OWL Ontology between formats")
+            .author("Phillip Lord")
+            .arg(
+                Arg::with_name("INPUT")
+                    .help("Sets the input file to use")
+                    .required(true)
+                    .index(1),
+            )
+            .arg(
+                Arg::with_name("to")
+                    .long("to")
+                    .takes_value(true)
+                    .required(true)
+                    .help(
+                        "The format to convert to: owx, ofn, omn, owl, \
+                         or any RDF syntax oxrdfio supports (ttl, nt, nq, trig, jsonld, n3)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("to-file")
+                    .long("to-file")
+                    .takes_value(true)
+                    .help("Write the converted output to this file instead of stdout"),
+            ),
+    )
+}
+
+pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
+    let input = matches.value_of("INPUT").unwrap();
+    let to = matches.value_of("to").unwrap();
+
+    let res = parse_path(Path::new(input), parser_config(matches))?;
+    let amo: RcComponentMappedOntology = res.into();
+
+    match matches.value_of("to-file") {
+        Some(to_file) => {
+            write(to, File::create(to_file)?, &amo)?;
+        }
+        None => {
+            write(to, stdout(), &amo)?;
+            // Finish off nicely
+            println!();
+        }
+    }
+
+    Ok(())
+}

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -27,6 +27,19 @@ pub mod error {
     }
 }
 
+/// The `oxrdfio::RdfFormat` that `extension` denotes, if any. `"owl"`
+/// is horned-owl's own long-standing alias for RDF/XML; every other
+/// extension is whatever [`oxrdfio::RdfFormat::from_extension`]
+/// recognises (`ttl`, `nt`, `nq`, `trig`, `json`/`jsonld`, `n3`,
+/// `rdf`, `xml`).
+fn rdf_format_for_extension(extension: &str) -> Option<oxrdfio::RdfFormat> {
+    if extension == "owl" {
+        Some(oxrdfio::RdfFormat::RdfXml)
+    } else {
+        oxrdfio::RdfFormat::from_extension(extension)
+    }
+}
+
 pub fn write<A: ForIRI, AA: ForIndex<A>, W: StdWrite>(
     format: &str,
     write: W,
@@ -36,11 +49,7 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: StdWrite>(
         "owx" => horned_owl::io::owx::writer::write(write, ont, None),
         "ofn" => horned_owl::io::ofn::writer::write(write, ont, None),
         "omn" => horned_owl::io::omn::write(write, ont, None),
-        "owl" | "ttl" => horned_owl::io::rdf::writer::write_to_rdf_format(write, ont, format),
-
-        _ => Err(HornedError::CommandError(format!(
-            "Format is unknown: {format}"
-        ))),
+        _ => horned_owl::io::rdf::writer::write_to_rdf_format(write, ont, format),
     }
 }
 
@@ -49,7 +58,7 @@ pub fn path_type(path: &Path) -> Option<ResourceType> {
         Some("ofn") => Some(ResourceType::OFN),
         Some("owx") => Some(ResourceType::OWX),
         Some("omn") => Some(ResourceType::OMN),
-        Some("owl") => Some(ResourceType::RDF),
+        Some(ext) if rdf_format_for_extension(ext).is_some() => Some(ResourceType::RDF),
         _ => None,
     }
 }
@@ -77,7 +86,10 @@ pub fn parse_path(
         Some(ResourceType::RDF) => {
             let b = Build::new();
             let iri = horned_owl::resolve::path_to_file_iri(&b, path);
-            ParserOutput::rdf(horned_owl::io::rdf::closure_reader::read(&iri, config)?)
+            ParserOutput::rdf(horned_owl::io::rdf::closure_reader::read(
+                &iri,
+                with_detected_rdf_format(path, config),
+            )?)
         }
         None => {
             return Err(HornedError::CommandError(format!(
@@ -85,6 +97,18 @@ pub fn parse_path(
             )));
         }
     })
+}
+
+/// Fill in `config.rdf.format` from `path`'s extension, unless the
+/// caller already set one explicitly.
+fn with_detected_rdf_format(path: &Path, mut config: ParserConfiguration) -> ParserConfiguration {
+    if config.rdf.format.is_none() {
+        config.rdf.format = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .and_then(rdf_format_for_extension);
+    }
+    config
 }
 
 /// Parse but only as far as the imports, if that makes sense.
@@ -107,6 +131,7 @@ pub fn parse_imports(
         }
         Some(ResourceType::RDF) => {
             let b = Build::new();
+            let config = with_detected_rdf_format(path, config);
             let mut p = horned_owl::io::rdf::reader::parser_with_build(&mut bufreader, &b, config);
             p.parse_imports()?;
             ParserOutput::rdf(p.as_ontology_and_incomplete())

--- a/horned-bin/tests/test_horned_convert.rs
+++ b/horned-bin/tests/test_horned_convert.rs
@@ -1,0 +1,116 @@
+use assert_cmd::cargo;
+use assert_cmd::prelude::*; // Add methods on commands
+
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn integration_convert_ofn_to_owx() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-convert"));
+
+    cmd.arg("../src/ont/owl-functional/and.ofn")
+        .arg("--to")
+        .arg("owx");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("<Ontology"));
+
+    Ok(())
+}
+
+#[test]
+fn integration_convert_owx_to_ttl() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-convert"));
+
+    cmd.arg("../src/ont/owl-xml/and.owx").arg("--to").arg("ttl");
+    cmd.assert().success().stdout(predicate::str::contains(
+        "http://www.w3.org/2002/07/owl#Class",
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn integration_convert_rdf_to_ofn() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-convert"));
+
+    cmd.arg("../src/ont/owl-rdf/and.owl").arg("--to").arg("ofn");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Ontology("));
+
+    Ok(())
+}
+
+#[test]
+fn integration_convert_to_file() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = mktemp::Temp::new_dir()?;
+    let out_file = dir.join("and.owx");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-convert"));
+    cmd.arg("../src/ont/owl-functional/and.ofn")
+        .arg("--to")
+        .arg("owx")
+        .arg("--to-file")
+        .arg(&out_file);
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    let written = std::fs::read_to_string(&out_file)?;
+    assert!(written.contains("<Ontology"));
+
+    Ok(())
+}
+
+#[test]
+fn integration_convert_round_trip_via_ttl() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = mktemp::Temp::new_dir()?;
+    let ttl_file = dir.join("and.ttl");
+
+    // Convert the OFN fixture to Turtle...
+    let mut to_ttl = Command::new(cargo::cargo_bin!("horned-convert"));
+    to_ttl
+        .arg("../src/ont/owl-functional/and.ofn")
+        .arg("--to")
+        .arg("ttl")
+        .arg("--to-file")
+        .arg(&ttl_file);
+    to_ttl.assert().success();
+
+    // ...then read that Turtle file back and convert it to OFN.
+    let mut from_ttl = Command::new(cargo::cargo_bin!("horned-convert"));
+    from_ttl.arg(&ttl_file).arg("--to").arg("ofn");
+    from_ttl
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Ontology("));
+
+    Ok(())
+}
+
+#[test]
+fn integration_convert_unknown_output_format() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-convert"));
+
+    cmd.arg("../src/ont/owl-functional/and.ofn")
+        .arg("--to")
+        .arg("bogus");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Format is unknown"));
+
+    Ok(())
+}
+
+#[test]
+fn integration_convert_unknown_input_extension() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-convert"));
+
+    cmd.arg("../src/ont/owl-functional/and.bogus")
+        .arg("--to")
+        .arg("ofn");
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Cannot parse a file of this format",
+    ));
+
+    Ok(())
+}

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -36,6 +36,11 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: Write>(
     write_to_rdf_formatter(ont, f)
 }
 
+/// Write a component mapped ontology as RDF in the format named by
+/// `format`, which is either `"owl"` (horned-owl's own alias for
+/// RDF/XML) or any extension recognised by
+/// [`oxrdfio::RdfFormat::from_extension`] (`ttl`, `nt`, `nq`, `trig`,
+/// `json`/`jsonld`, `n3`, `rdf`, `xml`).
 pub fn write_to_rdf_format<A: ForIRI, AA: ForIndex<A>, W: Write>(
     write: W,
     ont: &ComponentMappedOntology<A, AA>,
@@ -45,12 +50,19 @@ pub fn write_to_rdf_format<A: ForIRI, AA: ForIndex<A>, W: Write>(
         WriterQuadSerializerAdaptor::new(RdfSerializer::from_format(format).for_writer(write))
     };
 
-    match format {
-        "owl" => crate::io::rdf::writer::write(write, ont),
-        "ttl" => write_to_rdf_formatter(ont, serial(write, oxrdfio::RdfFormat::NTriples)),
-        _ => Err(HornedError::CommandError(format!(
-            "Format is unknown: {format}"
-        ))),
+    // "owl" is horned-owl's own long-standing extension for RDF/XML;
+    // oxrdfio::RdfFormat::from_extension doesn't recognise it (it
+    // only knows "rdf"/"xml" for RdfXml), so special-case it here.
+    let rdf_format = if format == "owl" {
+        oxrdfio::RdfFormat::RdfXml
+    } else {
+        oxrdfio::RdfFormat::from_extension(format)
+            .ok_or_else(|| HornedError::CommandError(format!("Format is unknown: {format}")))?
+    };
+
+    match rdf_format {
+        oxrdfio::RdfFormat::RdfXml => crate::io::rdf::writer::write(write, ont),
+        other => write_to_rdf_formatter(ont, serial(write, other)),
     }
 }
 


### PR DESCRIPTION
## Summary
- horned-convert enables conversion between different formats, including all RDF formats supported by oxrdfio.
- Fixes write_to_rdf_format's "ttl" case, which was wired to RdfFormat::NTriples instead of RdfFormat::Turtle.

Closes #80
Closes #191

## Test plan
- [x] `cargo test --workspace` passes (1292 lib tests, 20 manchester conformance tests, 49 doctests, and horned-bin integration tests including the new `test_horned_convert.rs`)
- [x] `cargo fmt --check` / `cargo clippy` clean
- [x] Manually verified `horned convert` round-tripping ofn/owx/owl/ttl, `--to-file`, and error paths for unknown input/output formats