### PR TITLE
Wire Manchester syntax (.omn) generation into bubo, force cargo clean after

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,18 @@ bench-prepare:
 
 
 ## Build the Unit test Ontology code
+##
+## `test_resources` (the test-generator proc-macro driving src/ont/*
+## fixture discovery) globs those directories at compile time with
+## nothing telling Cargo to invalidate the build when files there
+## change, so a stale test binary can silently miss new/changed/removed
+## fixtures. `cargo clean` unconditionally after bubo runs so the next
+## `cargo test` always sees current fixtures.
 just-bubo:
 	$(MAKE) -C src/ont/bubo
+	cargo clean
 
-bubo: just-bubo clean test
+bubo: just-bubo test
 
 clean:
 	cargo clean

--- a/src/ont/bubo/Makefile
+++ b/src/ont/bubo/Makefile
@@ -6,10 +6,10 @@
 BUBO=$(wildcard ../../../dev/bubo-*)
 
 define build_template
-  ../owl-rdf/$(1).owl ../owl-xml/$(1).owx ../owl-ttl/$1.ttl ../owl-functional/$(1).ofn&: $1.clj
+  ../owl-rdf/$(1).owl ../owl-xml/$(1).owx ../owl-ttl/$1.ttl ../owl-functional/$(1).ofn ../owl-manchester/$(1).omn&: $1.clj
 	$(BUBO) $1.clj
 
-  $(2)+=../owl-rdf/$(1).owl ../owl-xml/$(1).owx ../owl-ttl/$(1).ttl ../owl-functional/$(1).ofn
+  $(2)+=../owl-rdf/$(1).owl ../owl-xml/$(1).owx ../owl-ttl/$(1).ttl ../owl-functional/$(1).ofn ../owl-manchester/$(1).omn
 endef
 
 ## Exclude these because they will be generated when something else imports them

--- a/src/ont/bubo/save.clj
+++ b/src/ont/bubo/save.clj
@@ -17,4 +17,5 @@
   (save-one "owl-rdf" ".owl" :rdf)
   (save-one "owl-xml" ".owx" :owl)
   (save-one "owl-ttl" ".ttl" :ttl)
-  (save-one "owl-functional" ".ofn" (FunctionalSyntaxDocumentFormat.)))
+  (save-one "owl-functional" ".ofn" (FunctionalSyntaxDocumentFormat.))
+  (save-one "owl-manchester" ".omn" :omn))

--- a/src/ont/owl-manchester/ambiguous/annotation-with-anonymous.omn
+++ b/src/ont/owl-manchester/ambiguous/annotation-with-anonymous.omn
@@ -1,0 +1,27 @@
+## This file was created by Tawny-OWL
+## It should not be edited by hand
+Prefix: o: <http://www.example.com/iri#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+Prefix: : <http://www.example.com/iri>
+
+
+
+Ontology: <http://www.example.com/iri>
+<http://www.example.com/viri>
+
+AnnotationProperty: rdfs:comment
+
+    
+Datatype: rdf:langString
+
+    
+Individual: _:genid2147483648
+
+    Annotations: 
+        rdfs:comment "fred"@en
+    
+    

--- a/src/ont/owl-manchester/ambiguous/multi-same-individual.omn
+++ b/src/ont/owl-manchester/ambiguous/multi-same-individual.omn
@@ -1,0 +1,30 @@
+## This file was created by Tawny-OWL
+## It should not be edited by hand
+Prefix: o: <http://www.example.com/iri#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+Prefix: : <http://www.example.com/iri>
+
+
+
+Ontology: <http://www.example.com/iri>
+<http://www.example.com/viri>
+
+Individual: o:p
+
+    
+Individual: o:q
+
+    
+Individual: o:r
+
+    
+Individual: o:s
+
+    
+SameIndividual: 
+    o:p,o:q,o:r,o:s
+

--- a/src/ont/owl-manchester/ambiguous/nonround-test.omn
+++ b/src/ont/owl-manchester/ambiguous/nonround-test.omn
@@ -1,0 +1,15 @@
+## This file was created by Tawny-OWL
+## It should not be edited by hand
+Prefix: o: <http://www.example.com/iri#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+Prefix: : <http://www.example.com/iri>
+
+
+
+Ontology: <http://www.example.com/iri>
+<http://www.example.com/viri>
+

--- a/src/ont/owl-manchester/nested-annotation-on-annotation.omn
+++ b/src/ont/owl-manchester/nested-annotation-on-annotation.omn
@@ -1,0 +1,32 @@
+## This file was created by Tawny-OWL
+## It should not be edited by hand
+Prefix: o: <http://www.example.com/iri#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+Prefix: : <http://www.example.com/iri>
+
+
+
+Ontology: <http://www.example.com/iri>
+<http://www.example.com/viri>
+
+AnnotationProperty: rdfs:comment
+
+    
+Datatype: rdf:langString
+
+    
+Class: o:A
+
+    Annotations: 
+        
+            Annotations: 
+                         Annotations: rdfs:comment "Nested Comment"@en
+                                     
+                                     rdfs:comment "Comment on Comment"@en
+        rdfs:comment "Comment on Class"@en
+    
+    

--- a/src/ont/owl-manchester/withimport/import-property.omn
+++ b/src/ont/owl-manchester/withimport/import-property.omn
@@ -1,0 +1,29 @@
+## This file was created by Tawny-OWL
+## It should not be edited by hand
+Prefix: o: <http://www.example.com/iri#>
+Prefix: other: <http://www.example.com/other-property#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+Prefix: : <http://www.example.com/iri>
+
+
+
+Ontology: <http://www.example.com/iri>
+<http://www.example.com/viri>
+Import: <http://www.example.com/other-property>
+
+ObjectProperty: other:other-o
+
+    
+Class: o:A
+
+    
+Class: o:B
+
+    SubClassOf: 
+        other:other-o some o:A
+    
+    

--- a/src/ont/owl-manchester/withimport/other-property.omn
+++ b/src/ont/owl-manchester/withimport/other-property.omn
@@ -1,0 +1,18 @@
+## This file was created by Tawny-OWL
+## It should not be edited by hand
+Prefix: other: <http://www.example.com/other-property#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+Prefix: : <http://www.example.com/other-property>
+
+
+
+Ontology: <http://www.example.com/other-property>
+<http://www.example.com/other-property-viri>
+
+ObjectProperty: other:other-o
+
+    


### PR DESCRIPTION
## Summary
- `save.clj`'s `save-all` now also saves the Manchester (`:omn`) format via `tawny.owl`'s existing `save-ontology` support for it — previously `.omn` fixtures were hand/one-off generated and never tracked by the bubo pipeline.
- `src/ont/bubo/Makefile`'s `build_template` now lists `.omn` as an output alongside the other four formats, so `make -C src/ont/bubo` regenerates it like the rest.
- Regenerated the 6 fixtures that were missing/stale as a result; the other four formats came out byte-identical, confirming bubo's output is deterministic and nothing else was disturbed.
- `just-bubo` now runs `cargo clean` unconditionally after bubo runs — `test_resources` globs `src/ont/` at compile time with no `build.rs` tracking those paths, so a stale test binary can silently miss fixture changes.

Fixes #197.

## Test plan
- [x] `cargo test --lib --bins --tests -- --skip integration` — 1296 passed, 0 failed
- [x] `cargo fmt --check` / `cargo clippy` clean
- [x] `git status` clean (no untracked files, pre-commit hook's untracked-files check passes)