### PR TITLE
Update ureq to 3.3.0, make the remote-resolution body size limit configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pest_derive = "2.7.8"
 pretty_rdf={workspace=true}
 oxrdf={workspace=true}
 oxrdfio={workspace=true}
-ureq={version="2.1.1", optional=true}
+ureq={version="3.3.0", optional=true}
 
 [workspace]
 members=["horned-bin"]

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -159,7 +159,7 @@ pub fn materialize(
     // Can we just do this with parse_iri method from OxIri?
 
     let file_pathbuf = match parsed {
-        Result::Ok(_) => ensure_local(&b.iri(file_or_iri), None)?,
+        Result::Ok(_) => ensure_local(&b.iri(file_or_iri), None, config.remote_body_limit)?,
         Result::Err(_) => PathBuf::from_str(file_or_iri).expect("Result is infallable"),
     };
 
@@ -170,12 +170,13 @@ pub fn materialize(
 fn ensure_local(
     iri: &IRI<RcStr>,
     relative_doc_iri: Option<&IRI<RcStr>>,
+    remote_body_limit: u64,
 ) -> Result<PathBuf, HornedError> {
     let local_path = localize_iri_favored(iri, relative_doc_iri);
 
     if !local_path.exists() {
         println!("Retrieving Ontology: {}", iri);
-        let imported_data = strict_resolve_iri(iri)?;
+        let imported_data = strict_resolve_iri(iri, remote_body_limit)?;
         println!("Saving to {}", local_path.display());
         let mut file = File::create(&local_path)?;
         file.write_all(imported_data.as_bytes())?;
@@ -201,7 +202,7 @@ fn materialize_1<'a>(
     for i in import {
         if !done.contains(&i.0) {
             done.push(i.0.clone());
-            let local_path = ensure_local(&i.0, Some(&doc_iri))?;
+            let local_path = ensure_local(&i.0, Some(&doc_iri), config.remote_body_limit)?;
 
             if recurse {
                 materialize_1(&local_path, config, done, true)?;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -48,7 +48,7 @@ impl<A: ForIRI, AA: ForIndex<A>> ParserOutput<A, AA> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParserConfiguration {
     /// In lax mode, parsers tolerate content that would otherwise be a
     /// parse error -- see individual readers for exactly what this
@@ -58,8 +58,26 @@ pub struct ParserConfiguration {
     /// OFN and OMN readers do not yet have a lax mode, so setting it
     /// has no effect on those formats.
     pub lax: bool,
+    /// The maximum number of bytes to read from a single remote
+    /// (`http`/`https`) IRI resolution, such as when following an
+    /// `owl:imports` closure. Defaults to `u64::MAX` (no limit),
+    /// matching the unbounded behaviour of pre-3.x `ureq`. Lower this
+    /// if resolving IRIs from untrusted sources where an oversized
+    /// response could exhaust memory.
+    pub remote_body_limit: u64,
     pub rdf: RDFParserConfiguration,
     pub owx: OWXParserConfiguration,
+}
+
+impl Default for ParserConfiguration {
+    fn default() -> Self {
+        ParserConfiguration {
+            lax: false,
+            remote_body_limit: u64::MAX,
+            rdf: RDFParserConfiguration::default(),
+            owx: OWXParserConfiguration::default(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -77,7 +77,8 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> ClosureOntologyParse
         source_iri: &IRI<A>,
         relative_doc_iri: Option<&IRI<A>>,
     ) -> Result<Vec<IRI<A>>, HornedError> {
-        let (new_doc_iri, s) = resolve_iri(source_iri, relative_doc_iri)?;
+        let (new_doc_iri, s) =
+            resolve_iri(source_iri, relative_doc_iri, self.config.remote_body_limit)?;
         self.parse_content_from_iri(s, relative_doc_iri, new_doc_iri)
     }
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -615,7 +615,10 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
     ) -> OntologyParser<'a, A, AA, O> {
         OntologyParser::from_bufread(
             b,
-            &mut Cursor::new(strict_resolve_iri(iri).expect("the IRI should resolve successfully")),
+            &mut Cursor::new(
+                strict_resolve_iri(iri, config.remote_body_limit)
+                    .expect("the IRI should resolve successfully"),
+            ),
             config,
         )
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -179,11 +179,16 @@ pub fn localize_iri_favored<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
 ///
 /// Should the local resolution fail, remote access is used instead.
 ///
+/// `remote_body_limit` bounds the number of bytes read from a remote
+/// response if resolution falls back to a network fetch -- see
+/// [strict_resolve_iri].
+///
 /// Returns the doc IRI from which it was resolved, the content or an
 /// error.
 pub fn resolve_iri<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
     iri: &IRI<A>,
     doc_iri: IO,
+    remote_body_limit: u64,
 ) -> Result<(IRI<A>, String), HornedError> {
     let b = Build::new();
 
@@ -235,7 +240,7 @@ pub fn resolve_iri<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
     }
 
     // All attempts to resolve it locally have failed, so try remote
-    Ok((iri.clone(), strict_resolve_iri(iri)?))
+    Ok((iri.clone(), strict_resolve_iri(iri, remote_body_limit)?))
 }
 
 /// Resolve the contents of the IRI as a String.
@@ -243,14 +248,29 @@ pub fn resolve_iri<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
 /// This functions only over "http(s)" IRIs and will not resolve any
 /// other form of IRI.
 ///
+/// `remote_body_limit` caps the number of bytes read from the
+/// response body; use `u64::MAX` for no limit.
+///
 /// Fails with panic if the `remote` feature is not enabled.
 #[cfg(feature = "remote")]
-pub fn strict_resolve_iri<A: ForIRI>(iri: &IRI<A>) -> Result<String, HornedError> {
-    ureq::get(iri).call()?.into_string().map_err(|e| e.into())
+pub fn strict_resolve_iri<A: ForIRI>(
+    iri: &IRI<A>,
+    remote_body_limit: u64,
+) -> Result<String, HornedError> {
+    ureq::get(iri.as_ref())
+        .call()?
+        .body_mut()
+        .with_config()
+        .limit(remote_body_limit)
+        .read_to_string()
+        .map_err(|e| e.into())
 }
 
 #[cfg(not(feature = "remote"))]
-pub fn strict_resolve_iri<A: ForIRI>(iri: &IRI<A>) -> Result<String, HornedError> {
+pub fn strict_resolve_iri<A: ForIRI>(
+    iri: &IRI<A>,
+    _remote_body_limit: u64,
+) -> Result<String, HornedError> {
     Err(HornedError::ImportError(format!(
         "cannot resolve IRI {iri} remotely: the 'remote' feature is not enabled"
     )))
@@ -374,7 +394,7 @@ mod test {
 
         // This does network access (to example.com). This cannot be
         // guaranteed to succeed. Perhaps we don't need this test at all.
-        assert!(strict_resolve_iri(&i).is_ok());
+        assert!(strict_resolve_iri(&i, u64::MAX).is_ok());
     }
 
     #[test]
@@ -384,7 +404,7 @@ mod test {
         let doc_iri = b.iri("file://Cargo.toml");
 
         let bikepath_str = ::std::fs::read_to_string("bikepath.md").unwrap();
-        let (_, iri_str) = resolve_iri(&i, &doc_iri).unwrap();
+        let (_, iri_str) = resolve_iri(&i, &doc_iri, u64::MAX).unwrap();
         assert_eq!(bikepath_str, iri_str);
     }
 
@@ -393,8 +413,12 @@ mod test {
         let b = Build::new_rc();
         let tester = |iri, resolve_to, doc_iri| {
             let read_str = ::std::fs::read_to_string(format!("dev/resolve/{resolve_to}")).unwrap();
-            let (_, iri_str) =
-                resolve_iri(&b.iri(iri), &b.iri(format!("file://dev/resolve/{doc_iri}"))).unwrap();
+            let (_, iri_str) = resolve_iri(
+                &b.iri(iri),
+                &b.iri(format!("file://dev/resolve/{doc_iri}")),
+                u64::MAX,
+            )
+            .unwrap();
             assert_eq!(read_str, iri_str);
         };
 


### PR DESCRIPTION
## Summary
- `ureq` 2.1.1 → 3.3.0. Migrates `strict_resolve_iri` to the 3.x API.
- ureq 3.x caps `read_to_string()`/`read_to_vec()` at 10MB by default unless routed through `with_config().limit(n)` — confirmed this is exactly the issue #163 describes (tools fetching larger remote ontologies could silently fail).
- New `ParserConfiguration::remote_body_limit: u64` (default `u64::MAX`, matching pre-3.x ureq's unbounded behaviour), threaded through `resolve_iri`, `strict_resolve_iri`, the RDF closure reader, and `horned-bin`'s materialize path. This is a breaking signature change to `resolve_iri`/`strict_resolve_iri` (both gained a `remote_body_limit` parameter).

No CLI flag exposes this yet — deliberately left as a separate follow-up. `horned-bin`'s `parser_config()` only wires up `--lax` today; `--remote-body-limit` is a distinct concern (bounding network reads during `owl:imports` closure-following, which any parsing subcommand can trigger, not just `horned-materialize`) and deserves its own design pass on flag naming/units/default rather than being bundled in here.

Closes #163.

## Test plan
- [x] `cargo test --lib --bins --tests -- --skip integration` — 1313 passed, 0 failed
- [x] `cargo fmt --check` / `cargo clippy` clean
- [x] `--no-default-features` (remote feature off) still compiles