### PR TITLE
Add global CLI options on horned: --lax, --remote-body-limit, --local-only

### DIFF
--- a/horned-bin/src/bin/horned.rs
+++ b/horned-bin/src/bin/horned.rs
@@ -21,23 +21,25 @@ fn main() -> Result<(), HornedError> {
 }
 
 fn app() -> App<'static> {
-    App::new("horned")
-        .version("0.2")
-        .about("Command Line tools for OWL Ontologies")
-        .author("Filippo De Bortoli <filippo.de_bortoli@tu-dresden.de>")
-        .subcommand_required(true)
-        .arg_required_else_help(true)
-        .subcommand(horned_big::app("big"))
-        .subcommand(horned_compare::app("compare"))
-        .subcommand(horned_convert::app("convert"))
-        .subcommand(horned_dump::app("dump"))
-        .subcommand(horned_materialize::app("materialize"))
-        .subcommand(horned_parse::app("parse"))
-        .subcommand(horned_round::app("round"))
-        .subcommand(horned_summary::app("summary"))
-        .subcommand(horned_triples::app("triples"))
-        .subcommand(horned_unparsed::app("unparsed"))
-        .subcommand(horned_validate::app("validate"))
+    horned_bin::config::parser_app_global(
+        App::new("horned")
+            .version("0.3")
+            .about("Command Line tools for OWL Ontologies")
+            .author("Filippo De Bortoli <filippo.de_bortoli@tu-dresden.de>,\nPhillip Lord <phillip.lord@newcastle.ac.uk ")
+            .subcommand_required(true)
+            .arg_required_else_help(true),
+    )
+    .subcommand(horned_big::app("big"))
+    .subcommand(horned_compare::app("compare"))
+    .subcommand(horned_convert::app("convert"))
+    .subcommand(horned_dump::app("dump"))
+    .subcommand(horned_materialize::app("materialize"))
+    .subcommand(horned_parse::app("parse"))
+    .subcommand(horned_round::app("round"))
+    .subcommand(horned_summary::app("summary"))
+    .subcommand(horned_triples::app("triples"))
+    .subcommand(horned_unparsed::app("unparsed"))
+    .subcommand(horned_validate::app("validate"))
 }
 
 fn matcher(matches: ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_compare.rs
+++ b/horned-bin/src/bin/horned_compare.rs
@@ -5,12 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    naming::name,
-    parse_path,
-    summary::summarize,
-};
+use horned_bin::{config::parser_config, naming::name, parse_path, summary::summarize};
 use horned_owl::error::HornedError;
 
 use std::path::Path;
@@ -22,24 +17,22 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Compare two OWL files")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT-A")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            )
-            .arg(
-                Arg::with_name("INPUT-B")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(2),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Compare two OWL files")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT-A")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("INPUT-B")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(2),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_convert.rs
+++ b/horned-bin/src/bin/horned_convert.rs
@@ -5,10 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    parse_path, write,
-};
+use horned_bin::{config::parser_config, parse_path, write};
 
 use horned_owl::error::HornedError;
 use horned_owl::ontology::component_mapped::RcComponentMappedOntology;
@@ -22,34 +19,32 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Convert an OWL Ontology between formats")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            )
-            .arg(
-                Arg::with_name("to")
-                    .long("to")
-                    .takes_value(true)
-                    .required(true)
-                    .help(
-                        "The format to convert to: owx, ofn, omn, owl, \
-                         or any RDF syntax oxrdfio supports (ttl, nt, nq, trig, jsonld, n3)",
-                    ),
-            )
-            .arg(
-                Arg::with_name("to-file")
-                    .long("to-file")
-                    .takes_value(true)
-                    .help("Write the converted output to this file instead of stdout"),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Convert an OWL Ontology between formats")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("to")
+                .long("to")
+                .takes_value(true)
+                .required(true)
+                .help(
+                    "The format to convert to: owx, ofn, omn, owl, \
+                     or any RDF syntax oxrdfio supports (ttl, nt, nq, trig, jsonld, n3)",
+                ),
+        )
+        .arg(
+            Arg::with_name("to-file")
+                .long("to-file")
+                .takes_value(true)
+                .help("Write the converted output to this file instead of stdout"),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_dump.rs
+++ b/horned-bin/src/bin/horned_dump.rs
@@ -5,10 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    parse_path,
-};
+use horned_bin::{config::parser_config, parse_path};
 
 use horned_owl::{error::HornedError, ontology::set::SetOntology};
 
@@ -21,19 +18,17 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Parse an OWL File and dump the data structures")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            )
-            .arg(Arg::with_name("incomplete").long("incomplete").short('l')),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Parse an OWL File and dump the data structures")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
+        .arg(Arg::with_name("incomplete").long("incomplete").short('l'))
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_materialize.rs
+++ b/horned-bin/src/bin/horned_materialize.rs
@@ -5,10 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    materialize,
-};
+use horned_bin::{config::parser_config, materialize};
 
 use horned_owl::error::HornedError;
 
@@ -19,18 +16,16 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Parse an OWL file and download all the imports.")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Parse an OWL file and download all the imports.")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_parse.rs
+++ b/horned-bin/src/bin/horned_parse.rs
@@ -5,10 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    parse_path,
-};
+use horned_bin::{config::parser_config, parse_path};
 
 use horned_owl::error::HornedError;
 
@@ -21,18 +18,16 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Parse an OWL File")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Parse an OWL File")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_round.rs
+++ b/horned-bin/src/bin/horned_round.rs
@@ -5,10 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    parse_path,
-};
+use horned_bin::{config::parser_config, parse_path};
 
 use horned_owl::error::HornedError;
 use horned_owl::ontology::component_mapped::RcComponentMappedOntology;
@@ -22,18 +19,16 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Parse and Render an OWL Ontology")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Parse and Render an OWL Ontology")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_summary.rs
+++ b/horned-bin/src/bin/horned_summary.rs
@@ -5,12 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    naming::name,
-    parse_path,
-    summary::summarize,
-};
+use horned_bin::{config::parser_config, naming::name, parse_path, summary::summarize};
 
 use horned_owl::error::HornedError;
 
@@ -23,17 +18,15 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Summary Statistics for an OWL file.")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Summary Statistics for an OWL file.")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_unparsed.rs
+++ b/horned-bin/src/bin/horned_unparsed.rs
@@ -5,7 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::config::{parser_app, parser_config};
+use horned_bin::config::parser_config;
 use horned_owl::error::HornedError;
 use horned_owl::io::rdf::reader::ConcreteRDFOntology;
 use horned_owl::model::{RcAnnotatedComponent, RcStr};
@@ -19,18 +19,16 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Show unparsed OWL RDF.")
-            .author("Phillip Lord")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Show unparsed OWL RDF.")
+        .author("Phillip Lord")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/bin/horned_validate.rs
+++ b/horned-bin/src/bin/horned_validate.rs
@@ -5,10 +5,7 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{
-    config::{parser_app, parser_config},
-    parse_path,
-};
+use horned_bin::{config::parser_config, parse_path};
 
 use horned_owl::error::HornedError;
 
@@ -21,18 +18,16 @@ fn main() -> Result<(), HornedError> {
 }
 
 pub(crate) fn app(name: &str) -> App<'static> {
-    parser_app(
-        App::new(name)
-            .version("0.1")
-            .about("Validates an ontology against the OWL2 specification")
-            .author("Filippo De Bortoli")
-            .arg(
-                Arg::with_name("INPUT")
-                    .help("Sets the input file to use")
-                    .required(true)
-                    .index(1),
-            ),
-    )
+    App::new(name)
+        .version("0.1")
+        .about("Validates an ontology against the OWL2 specification")
+        .author("Filippo De Bortoli")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(true)
+                .index(1),
+        )
 }
 
 pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -159,7 +159,12 @@ pub fn materialize(
     // Can we just do this with parse_iri method from OxIri?
 
     let file_pathbuf = match parsed {
-        Result::Ok(_) => ensure_local(&b.iri(file_or_iri), None, config.remote_body_limit)?,
+        Result::Ok(_) => ensure_local(
+            &b.iri(file_or_iri),
+            None,
+            config.remote_body_limit,
+            config.local_only,
+        )?,
         Result::Err(_) => PathBuf::from_str(file_or_iri).expect("Result is infallable"),
     };
 
@@ -171,12 +176,13 @@ fn ensure_local(
     iri: &IRI<RcStr>,
     relative_doc_iri: Option<&IRI<RcStr>>,
     remote_body_limit: u64,
+    local_only: bool,
 ) -> Result<PathBuf, HornedError> {
     let local_path = localize_iri_favored(iri, relative_doc_iri);
 
     if !local_path.exists() {
         println!("Retrieving Ontology: {}", iri);
-        let imported_data = strict_resolve_iri(iri, remote_body_limit)?;
+        let imported_data = strict_resolve_iri(iri, remote_body_limit, local_only)?;
         println!("Saving to {}", local_path.display());
         let mut file = File::create(&local_path)?;
         file.write_all(imported_data.as_bytes())?;
@@ -202,13 +208,18 @@ fn materialize_1<'a>(
     for i in import {
         if !done.contains(&i.0) {
             done.push(i.0.clone());
-            let local_path = ensure_local(&i.0, Some(&doc_iri), config.remote_body_limit)?;
+            let local_path = ensure_local(
+                &i.0,
+                Some(&doc_iri),
+                config.remote_body_limit,
+                config.local_only,
+            )?;
 
             if recurse {
                 materialize_1(&local_path, config, done, true)?;
             }
         } else {
-            println!("Already materialized: {}", &i.0);
+            println!("Already materialized: {}", i.0);
         }
     }
 
@@ -359,18 +370,73 @@ pub mod config {
     use clap::ArgMatches;
     use horned_owl::io::ParserConfiguration;
 
-    pub fn parser_app(app: App<'static>) -> App<'static> {
+    /// Add parser-config options as *global* args on the unified `horned`
+    /// binary's top-level App (see `horned.rs`) -- with `global(true)`,
+    /// clap makes them available on every subcommand's own `ArgMatches`
+    /// regardless of whether the flag is given before or after the
+    /// subcommand name. Not called by the standalone single-subcommand
+    /// binaries (`horned-parse` etc): almost every subcommand parses
+    /// something, so these options belong on the shared `horned
+    /// <subcommand>` front door rather than duplicated per binary --
+    /// mirrors how `git` only offers most flags on `git <subcommand>`,
+    /// not on the individual `git-<subcommand>` binaries.
+    pub fn parser_app_global(app: App<'static>) -> App<'static> {
         app.arg(
             clap::arg!(--"lax")
                 .required(false)
+                .global(true)
                 .action(ArgAction::SetTrue)
                 .help("Parse in a lax manner"),
         )
+        .arg(
+            clap::arg!(--"remote-body-limit" <BYTES>)
+                .required(false)
+                .global(true)
+                .value_parser(clap::value_parser!(u64))
+                .help(
+                    "Maximum bytes to read from a remote IRI resolution \
+                     (e.g. while following owl:imports); unbounded if not given",
+                ),
+        )
+        .arg(
+            clap::arg!(--"local-only")
+                .required(false)
+                .global(true)
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Never access the network -- fail instead of resolving \
+                     an IRI (e.g. an owl:imports target) remotely",
+                ),
+        )
     }
 
+    /// `lax`/`remote-body-limit`/`local-only` are only registered on the
+    /// unified `horned` binary (see `parser_app_global`), not on the
+    /// standalone `horned-*` binaries -- so on those, `matches` won't have
+    /// these arg ids defined at all. `try_get_one` reports that as `Err`,
+    /// same as "not provided" reports `Ok(None)`; either way we fall back
+    /// to the off/unbounded default, whereas `get_one` panics on an
+    /// undefined id.
     pub fn parser_config(matches: &ArgMatches) -> ParserConfiguration {
         ParserConfiguration {
-            lax: *matches.get_one::<bool>("lax").unwrap_or(&false),
+            lax: matches
+                .try_get_one::<bool>("lax")
+                .ok()
+                .flatten()
+                .copied()
+                .unwrap_or(false),
+            remote_body_limit: matches
+                .try_get_one::<u64>("remote-body-limit")
+                .ok()
+                .flatten()
+                .copied()
+                .unwrap_or(u64::MAX),
+            local_only: matches
+                .try_get_one::<bool>("local-only")
+                .ok()
+                .flatten()
+                .copied()
+                .unwrap_or(false),
             ..Default::default()
         }
     }

--- a/horned-bin/tests/test_horned.rs
+++ b/horned-bin/tests/test_horned.rs
@@ -1,0 +1,61 @@
+use assert_cmd::cargo;
+use assert_cmd::prelude::*; // Add methods on commands
+
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn integration_local_only_allows_purely_local_parse() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned"));
+
+    cmd.arg("--local-only")
+        .arg("parse")
+        .arg("../src/ont/owl-rdf/and.owl");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Parse Complete"));
+
+    Ok(())
+}
+
+#[test]
+fn integration_local_only_blocks_remote_import() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = mktemp::Temp::new_dir()?;
+    let ont_file = dir.join("imports-unreachable.owl");
+
+    // RFC 5737 TEST-NET-1 (192.0.2.0/24): reserved for documentation, never
+    // routable. If --local-only did not short-circuit before the network
+    // call, this would hang/time out rather than fail fast.
+    std::fs::write(
+        &ont_file,
+        r#"<?xml version="1.0"?>
+<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="http://www.example.com/local-only-test">
+        <owl:imports rdf:resource="http://192.0.2.1/unreachable.owl"/>
+    </owl:Ontology>
+</rdf:RDF>
+"#,
+    )?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("horned"));
+    cmd.arg("--local-only").arg("parse").arg(&ont_file);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("local-only mode is enabled"));
+
+    Ok(())
+}
+
+#[test]
+fn integration_local_only_not_available_on_standalone_binary()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned-parse"));
+
+    cmd.arg("--local-only").arg("../src/ont/owl-rdf/and.owl");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("--local-only"));
+
+    Ok(())
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -65,6 +65,13 @@ pub struct ParserConfiguration {
     /// if resolving IRIs from untrusted sources where an oversized
     /// response could exhaust memory.
     pub remote_body_limit: u64,
+    /// If set, no network access is attempted at all during parsing --
+    /// resolving an IRI (e.g. following an `owl:imports` closure) that
+    /// isn't available locally fails with an error instead of falling
+    /// back to a remote fetch. `remote_body_limit` still bounds a fetch
+    /// in size if one happens; this instead prevents one happening at
+    /// all. Defaults to `false`.
+    pub local_only: bool,
     pub rdf: RDFParserConfiguration,
     pub owx: OWXParserConfiguration,
 }
@@ -74,6 +81,7 @@ impl Default for ParserConfiguration {
         ParserConfiguration {
             lax: false,
             remote_body_limit: u64::MAX,
+            local_only: false,
             rdf: RDFParserConfiguration::default(),
             owx: OWXParserConfiguration::default(),
         }

--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -77,8 +77,12 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> ClosureOntologyParse
         source_iri: &IRI<A>,
         relative_doc_iri: Option<&IRI<A>>,
     ) -> Result<Vec<IRI<A>>, HornedError> {
-        let (new_doc_iri, s) =
-            resolve_iri(source_iri, relative_doc_iri, self.config.remote_body_limit)?;
+        let (new_doc_iri, s) = resolve_iri(
+            source_iri,
+            relative_doc_iri,
+            self.config.remote_body_limit,
+            self.config.local_only,
+        )?;
         self.parse_content_from_iri(s, relative_doc_iri, new_doc_iri)
     }
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -616,7 +616,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
         OntologyParser::from_bufread(
             b,
             &mut Cursor::new(
-                strict_resolve_iri(iri, config.remote_body_limit)
+                strict_resolve_iri(iri, config.remote_body_limit, config.local_only)
                     .expect("the IRI should resolve successfully"),
             ),
             config,
@@ -716,7 +716,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
 
         self.stitch_seqs_1();
 
-        for (_, v) in self.bnode_seq.iter_mut() {
+        for v in self.bnode_seq.values_mut() {
             v.reverse();
         }
     }
@@ -2361,7 +2361,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 Self::group_triples(triple, &mut self.simple, &mut self.bnode);
 
                 // sort the triples, so that I can get a dependable order
-                for (_, vec) in self.bnode.iter_mut() {
+                for vec in self.bnode.values_mut() {
                     vec.sort();
                 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -177,7 +177,8 @@ pub fn localize_iri_favored<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
 /// same as the content at `iri`. This is done relative to `doc_iri`
 /// which will normally be the Document IRI of an importing ontology.
 ///
-/// Should the local resolution fail, remote access is used instead.
+/// Should the local resolution fail, remote access is used instead,
+/// unless `local_only` is set -- see [strict_resolve_iri].
 ///
 /// `remote_body_limit` bounds the number of bytes read from a remote
 /// response if resolution falls back to a network fetch -- see
@@ -189,6 +190,7 @@ pub fn resolve_iri<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
     iri: &IRI<A>,
     doc_iri: IO,
     remote_body_limit: u64,
+    local_only: bool,
 ) -> Result<(IRI<A>, String), HornedError> {
     let b = Build::new();
 
@@ -240,7 +242,10 @@ pub fn resolve_iri<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
     }
 
     // All attempts to resolve it locally have failed, so try remote
-    Ok((iri.clone(), strict_resolve_iri(iri, remote_body_limit)?))
+    Ok((
+        iri.clone(),
+        strict_resolve_iri(iri, remote_body_limit, local_only)?,
+    ))
 }
 
 /// Resolve the contents of the IRI as a String.
@@ -249,14 +254,24 @@ pub fn resolve_iri<'a, A: ForIRI + 'a, IO: Into<Option<&'a IRI<A>>>>(
 /// other form of IRI.
 ///
 /// `remote_body_limit` caps the number of bytes read from the
-/// response body; use `u64::MAX` for no limit.
+/// response body; use `u64::MAX` for no limit. If `local_only` is set,
+/// no network access is attempted at all -- this is the single point
+/// through which every remote fetch in this crate goes, so setting it
+/// is a hard guarantee, not just a best-effort default.
 ///
 /// Fails with panic if the `remote` feature is not enabled.
 #[cfg(feature = "remote")]
 pub fn strict_resolve_iri<A: ForIRI>(
     iri: &IRI<A>,
     remote_body_limit: u64,
+    local_only: bool,
 ) -> Result<String, HornedError> {
+    if local_only {
+        return Err(HornedError::ImportError(format!(
+            "cannot resolve IRI {iri} remotely: local-only mode is enabled"
+        )));
+    }
+
     ureq::get(iri.as_ref())
         .call()?
         .body_mut()
@@ -270,6 +285,7 @@ pub fn strict_resolve_iri<A: ForIRI>(
 pub fn strict_resolve_iri<A: ForIRI>(
     iri: &IRI<A>,
     _remote_body_limit: u64,
+    _local_only: bool,
 ) -> Result<String, HornedError> {
     Err(HornedError::ImportError(format!(
         "cannot resolve IRI {iri} remotely: the 'remote' feature is not enabled"
@@ -394,7 +410,17 @@ mod test {
 
         // This does network access (to example.com). This cannot be
         // guaranteed to succeed. Perhaps we don't need this test at all.
-        assert!(strict_resolve_iri(&i, u64::MAX).is_ok());
+        assert!(strict_resolve_iri(&i, u64::MAX, false).is_ok());
+    }
+
+    #[test]
+    fn local_only_blocks_remote_resolution() {
+        let b = Build::new_rc();
+        // A deliberately unroutable address (RFC 5737 TEST-NET-1): if
+        // local_only did not short-circuit before the network call, this
+        // would hang/time out rather than fail fast.
+        let i: IRI<_> = b.iri("http://192.0.2.1/does-not-matter.owl");
+        assert!(strict_resolve_iri(&i, u64::MAX, true).is_err());
     }
 
     #[test]
@@ -404,7 +430,7 @@ mod test {
         let doc_iri = b.iri("file://Cargo.toml");
 
         let bikepath_str = ::std::fs::read_to_string("bikepath.md").unwrap();
-        let (_, iri_str) = resolve_iri(&i, &doc_iri, u64::MAX).unwrap();
+        let (_, iri_str) = resolve_iri(&i, &doc_iri, u64::MAX, false).unwrap();
         assert_eq!(bikepath_str, iri_str);
     }
 
@@ -417,6 +443,7 @@ mod test {
                 &b.iri(iri),
                 &b.iri(format!("file://dev/resolve/{doc_iri}")),
                 u64::MAX,
+                false,
             )
             .unwrap();
             assert_eq!(read_str, iri_str);


### PR DESCRIPTION
## Summary
- Follow-up to #163: exposes `ParserConfiguration::remote_body_limit` on the CLI, plus a new `local_only` guarantee, and promotes `--lax` alongside them.
- Wired as **global args on the unified `horned` binary's subcommands only** (`config::parser_app_global` in `horned-bin/src/lib.rs`) — works in either position (`horned --lax parse foo.owl` and `horned parse --lax foo.owl` both work). The standalone binaries (`horned-parse`, `horned-materialize`, etc.) no longer take these flags at all, mirroring how `git` only offers most flags on `git <subcommand>`, not on individual `git-<subcommand>` binaries.
- New `ParserConfiguration::local_only` (default `false`). `strict_resolve_iri` in `src/resolve.rs` is the sole function that actually touches the network, so enforcing `local_only` there is a hard guarantee — verified with an RFC 5737 unroutable test address: without `--local-only` the command hangs on the network call, with it the command fails instantly with a clear error.
- Adds `horned-bin/tests/test_horned.rs`, the first integration test file for the unified `horned` binary.
- Also fixes two pre-existing clippy lints unrelated to this change but blocking the pre-commit hook (`clippy::for_kv_map` in `src/io/rdf/reader.rs`, a redundant reference in a `println!` in `horned-bin/src/lib.rs`).

## Test plan
- [x] `cargo test --workspace --lib --bins --tests -- --skip integration` — 1314 passed, 0 failed
- [x] `cargo test -p horned-bin --test test_horned` — 3/3 new integration tests pass
- [x] `cargo fmt --check` / `cargo clippy --workspace` clean
- [x] Manually verified: flag works before/after subcommand, absent from standalone binaries with a clean (non-panicking) error, `--local-only` blocks network access before any connection attempt