### PR TITLE
Add write benchmarks for all serialization formats

### DIFF
--- a/benches/horned.rs
+++ b/benches/horned.rs
@@ -1,11 +1,13 @@
 use criterion::criterion_main;
 
-mod io;
+mod io_read;
+mod io_write;
 mod iteration;
 mod model;
 
-use crate::io::io;
+use crate::io_read::io_read;
+use crate::io_write::io_write;
 use crate::iteration::iteration;
 use crate::model::model;
 
-criterion_main!(model, io, iteration);
+criterion_main!(model, io_read, io_write, iteration);

--- a/benches/io_read.rs
+++ b/benches/io_read.rs
@@ -7,7 +7,7 @@ use std::fs::{File, create_dir_all};
 use std::io::BufReader;
 use std::time::Duration;
 
-fn io_read(c: &mut Criterion) {
+fn bench_io_read(c: &mut Criterion) {
     let mut group = c.benchmark_group("io_read");
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
@@ -70,9 +70,9 @@ fn io_read(c: &mut Criterion) {
 }
 
 criterion_group! {
-    name = io;
+    name = io_read;
     config = Criterion::default()
     .sample_size(50)
     .measurement_time(Duration::from_secs(20));
-    targets = io_read
+    targets = bench_io_read
 }

--- a/benches/io_write.rs
+++ b/benches/io_write.rs
@@ -1,0 +1,81 @@
+use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration, criterion_group};
+use horned_owl::model::{Build, MutableOntology, RcStr};
+use horned_owl::ontology::component_mapped::RcComponentMappedOntology;
+use horned_owl::ontology::set::SetOntology;
+use horned_pretty_rdf::ox::WriterQuadSerializerAdaptor;
+use oxrdfio::RdfSerializer;
+use std::io::sink;
+use std::time::Duration;
+
+fn build_ontology(n: isize) -> RcComponentMappedOntology {
+    let b = Build::new_rc();
+    let mut o: SetOntology<RcStr> = SetOntology::new_rc();
+    for i in 1..=n {
+        o.declare(b.class(format!("https://www.example.com/o{}", i)));
+    }
+    o.into()
+}
+
+fn bench_io_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("io_write");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    for n in [10, 100, 1_000, 2500, 5000, 10_000].iter() {
+        let ont = build_ontology(*n);
+
+        // RDF/XML: pretty formatter (horned-pretty-rdf)
+        group.bench_function(BenchmarkId::new("rdf_xml_pretty_io_write", n), |b| {
+            b.iter(|| {
+                horned_owl::io::rdf::writer::write(sink(), &ont).ok();
+            })
+        });
+
+        // RDF/XML: plain oxrdfio serializer
+        group.bench_function(BenchmarkId::new("rdf_xml_plain_io_write", n), |b| {
+            b.iter(|| {
+                let f = WriterQuadSerializerAdaptor::new(
+                    RdfSerializer::from_format(oxrdfio::RdfFormat::RdfXml).for_writer(sink()),
+                );
+                horned_owl::io::rdf::writer::write_to_rdf_formatter(&ont, f).ok();
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("ttl_io_write", n), |b| {
+            b.iter(|| {
+                horned_owl::io::rdf::writer::write_to_rdf_format(sink(), &ont, "ttl").ok();
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("nt_io_write", n), |b| {
+            b.iter(|| {
+                horned_owl::io::rdf::writer::write_to_rdf_format(sink(), &ont, "nt").ok();
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("owx_io_write", n), |b| {
+            b.iter(|| {
+                horned_owl::io::owx::writer::write(sink(), &ont, None).ok();
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("ofn_io_write", n), |b| {
+            b.iter(|| {
+                horned_owl::io::ofn::writer::write(sink(), &ont, None).ok();
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("omn_io_write", n), |b| {
+            b.iter(|| {
+                horned_owl::io::omn::writer::write(sink(), &ont, None).ok();
+            })
+        });
+    }
+}
+
+criterion_group! {
+    name = io_write;
+    config = Criterion::default()
+    .sample_size(50)
+    .measurement_time(Duration::from_secs(20));
+    targets = bench_io_write
+}


### PR DESCRIPTION
## Summary

- Splits `benches/io.rs` into `benches/io_read.rs` and `benches/io_write.rs`
- Adds write benchmarks covering all serialization formats: RDF/XML pretty (horned-pretty-rdf), RDF/XML plain (oxrdfio), Turtle, N-Triples, OWX, OFN, OMN
- The pretty/plain RDF/XML split isolates the horned-pretty-rdf overhead vs the bare oxrdfio serializer

Closes #204