### PR TITLE
Add --input-format CLI option; horned-summary reports detected parse format

### DIFF
--- a/horned-bin/src/bin/horned_summary.rs
+++ b/horned-bin/src/bin/horned_summary.rs
@@ -5,7 +5,10 @@ use clap::App;
 use clap::Arg;
 use clap::ArgMatches;
 
-use horned_bin::{config::parser_config, naming::name, parse_path, summary::summarize};
+use horned_bin::{
+    config::parser_config, naming::name, parse_path, summary::summarize, with_detected_rdf_format,
+};
+use horned_owl::io::ResourceType;
 
 use horned_owl::error::HornedError;
 
@@ -35,7 +38,12 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
         .ok_or_else(|| HornedError::CommandError("A file name must be specified".to_string()))?;
 
     let config = parser_config(matches);
-    let (ont, p, i) = parse_path(Path::new(input), config)?.decompose();
+    let parsed = parse_path(Path::new(input), config)?;
+    let resource_type = parsed.resource_type();
+    let rdf_format = with_detected_rdf_format(Path::new(input), config)
+        .rdf
+        .format;
+    let (ont, p, i) = parsed.decompose();
 
     let summary = summarize(ont);
     println!("Ontology has:");
@@ -71,5 +79,24 @@ pub(crate) fn matcher(matches: &ArgMatches) -> Result<(), HornedError> {
         println!("\tAnnotations: {}", i.ann_map.len())
     }
 
+    let (english, mime) = format_names(&resource_type, rdf_format);
+    println!("\nParse Format: {english}");
+    println!("Mime Type: {mime}");
+
     Ok(())
+}
+
+fn format_names(
+    resource_type: &ResourceType,
+    rdf_format: Option<oxrdfio::RdfFormat>,
+) -> (&'static str, &'static str) {
+    match resource_type {
+        ResourceType::OFN => ("OWL Functional Syntax", "text/owl-functional"),
+        ResourceType::OWX => ("OWL/XML", "application/owl+xml"),
+        ResourceType::OMN => ("Manchester Syntax", "text/owl-manchester"),
+        ResourceType::RDF => match rdf_format {
+            Some(f) => (f.name(), f.media_type()),
+            None => ("RDF/XML", "application/rdf+xml"),
+        },
+    }
 }

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -59,8 +59,17 @@ pub fn path_type(path: &Path) -> Option<ResourceType> {
         Some("owx") => Some(ResourceType::OWX),
         Some("omn") => Some(ResourceType::OMN),
         Some(ext) if rdf_format_for_extension(ext).is_some() => Some(ResourceType::RDF),
-        _ => None,
+        _ => detect_from_path(path).map(|(rt, _)| rt),
     }
+}
+
+/// Peek at the first 512 bytes of a file and use content sniffing as a
+/// fallback when the extension is missing or unrecognised.
+fn detect_from_path(path: &Path) -> Option<(ResourceType, Option<oxrdfio::RdfFormat>)> {
+    use std::io::Read;
+    let mut buf = [0u8; 512];
+    let n = File::open(path).ok()?.read(&mut buf).ok()?;
+    horned_owl::io::detect_format(&buf[..n])
 }
 
 pub fn parse_path(
@@ -106,7 +115,8 @@ fn with_detected_rdf_format(path: &Path, mut config: ParserConfiguration) -> Par
         config.rdf.format = path
             .extension()
             .and_then(|s| s.to_str())
-            .and_then(rdf_format_for_extension);
+            .and_then(rdf_format_for_extension)
+            .or_else(|| detect_from_path(path).and_then(|(_, fmt)| fmt));
     }
     config
 }

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -2,7 +2,7 @@
 
 use horned_owl::{
     error::HornedError,
-    io::{ParserConfiguration, ParserOutput, ResourceType},
+    io::{InputFormat, ParserConfiguration, ParserOutput, ResourceType},
     model::{Build, ForIRI, IRI, MutableOntology, OntologyID, RcAnnotatedComponent, RcStr},
     ontology::{
         component_mapped::{ComponentMappedOntology, RcComponentMappedOntology},
@@ -53,7 +53,15 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: StdWrite>(
     }
 }
 
-pub fn path_type(path: &Path) -> Option<ResourceType> {
+pub fn path_type(path: &Path, config: &ParserConfiguration) -> Option<ResourceType> {
+    match config.input_format {
+        Some(InputFormat::OFN) => return Some(ResourceType::OFN),
+        Some(InputFormat::OWX) => return Some(ResourceType::OWX),
+        Some(InputFormat::OMN) => return Some(ResourceType::OMN),
+        Some(InputFormat::Rdf(_)) => return Some(ResourceType::RDF),
+        Some(InputFormat::Guess) => return detect_from_path(path).map(|(rt, _)| rt),
+        None => {}
+    }
     match path.extension().and_then(|s| s.to_str()) {
         Some("ofn") => Some(ResourceType::OFN),
         Some("owx") => Some(ResourceType::OWX),
@@ -76,7 +84,7 @@ pub fn parse_path(
     path: &Path,
     config: ParserConfiguration,
 ) -> Result<ParserOutput<RcStr, RcAnnotatedComponent>, HornedError> {
-    Ok(match path_type(path) {
+    Ok(match path_type(path, &config) {
         Some(ResourceType::OFN) => {
             let file = File::open(path)?;
             let mut bufreader = BufReader::new(file);
@@ -108,15 +116,22 @@ pub fn parse_path(
     })
 }
 
-/// Fill in `config.rdf.format` from `path`'s extension, unless the
+/// Fill in `config.rdf.format` from `path`'s extension or content, unless the
 /// caller already set one explicitly.
-fn with_detected_rdf_format(path: &Path, mut config: ParserConfiguration) -> ParserConfiguration {
+pub fn with_detected_rdf_format(
+    path: &Path,
+    mut config: ParserConfiguration,
+) -> ParserConfiguration {
     if config.rdf.format.is_none() {
-        config.rdf.format = path
-            .extension()
-            .and_then(|s| s.to_str())
-            .and_then(rdf_format_for_extension)
-            .or_else(|| detect_from_path(path).and_then(|(_, fmt)| fmt));
+        config.rdf.format = match config.input_format {
+            Some(InputFormat::Rdf(fmt)) => fmt,
+            Some(InputFormat::Guess) => detect_from_path(path).and_then(|(_, fmt)| fmt),
+            _ => path
+                .extension()
+                .and_then(|s| s.to_str())
+                .and_then(rdf_format_for_extension)
+                .or_else(|| detect_from_path(path).and_then(|(_, fmt)| fmt)),
+        };
     }
     config
 }
@@ -128,7 +143,7 @@ pub fn parse_imports(
 ) -> Result<ParserOutput<RcStr, RcAnnotatedComponent>, HornedError> {
     let file = File::open(path)?;
     let mut bufreader = BufReader::new(file);
-    Ok(match path_type(path) {
+    Ok(match path_type(path, &config) {
         Some(ResourceType::OFN) => {
             ParserOutput::ofn(horned_owl::io::owx::reader::read(&mut bufreader, config)?)
         }
@@ -378,7 +393,7 @@ pub mod config {
     use clap::App;
     use clap::ArgAction;
     use clap::ArgMatches;
-    use horned_owl::io::ParserConfiguration;
+    use horned_owl::io::{InputFormat, ParserConfiguration};
 
     /// Add parser-config options as *global* args on the unified `horned`
     /// binary's top-level App (see `horned.rs`) -- with `global(true)`,
@@ -418,6 +433,17 @@ pub mod config {
                      an IRI (e.g. an owl:imports target) remotely",
                 ),
         )
+        .arg(
+            clap::arg!(--"input-format" <FORMAT>)
+                .required(false)
+                .global(true)
+                .help(
+                    "Override input format detection. Accepted values: \
+                     owl, rdf, xml (RDF/XML), ttl (Turtle), nt (N-Triples), \
+                     owx (OWL/XML), ofn (Functional Syntax), omn (Manchester), \
+                     guess (detect from content)",
+                ),
+        )
     }
 
     /// `lax`/`remote-body-limit`/`local-only` are only registered on the
@@ -447,6 +473,11 @@ pub mod config {
                 .flatten()
                 .copied()
                 .unwrap_or(false),
+            input_format: matches
+                .try_get_one::<String>("input-format")
+                .ok()
+                .flatten()
+                .and_then(|s| s.parse::<InputFormat>().ok()),
             ..Default::default()
         }
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -137,9 +137,155 @@ impl<A: ForIRI, AA: ForIndex<A>> From<ParserOutput<A, AA>> for ComponentMappedOn
     }
 }
 
+/// Detect the serialization format of an OWL document from its content.
+///
+/// The detection logic is adapted from
+/// [`horned-roundtrip`](https://github.com/micheldumontier/horned-roundtrip)
+/// by Michel Dumontier et al., used under the MIT licence.
+///
+/// Returns `(ResourceType, rdf_format)` where `rdf_format` is set for RDF
+/// variants (RDF/XML, Turtle, N-Triples) and `None` for OWX, OFN, and OMN.
+/// Returns `None` when the format cannot be determined from the content.
+pub fn detect_format(bytes: &[u8]) -> Option<(ResourceType, Option<oxrdfio::RdfFormat>)> {
+    let s = String::from_utf8_lossy(bytes);
+    let s = s.strip_prefix('\u{feff}').unwrap_or(&s);
+    let trimmed = s.trim_start();
+
+    if trimmed.starts_with('<') {
+        // N-Triples / full-IRI-subject Turtle: `<iri> <iri>` on the first line.
+        if !trimmed.starts_with("<?")
+            && !trimmed.starts_with("<!")
+            && trimmed.lines().next().is_some_and(|l| l.contains("> <"))
+        {
+            return Some((ResourceType::RDF, Some(oxrdfio::RdfFormat::Turtle)));
+        }
+        // XML: sniff the root element name.
+        if let Some(root) = first_xml_element(trimmed) {
+            let local = root.rsplit(':').next().unwrap_or(root);
+            if local.eq_ignore_ascii_case("RDF") {
+                return Some((ResourceType::RDF, Some(oxrdfio::RdfFormat::RdfXml)));
+            }
+            if local.eq_ignore_ascii_case("Ontology") {
+                return Some((ResourceType::OWX, None));
+            }
+        }
+        return None;
+    }
+
+    // Text-syntax formats: skip blank lines and `#` comments.
+    for line in trimmed.lines() {
+        let l = line.trim_start();
+        if l.is_empty() || l.starts_with('#') {
+            continue;
+        }
+        let lower = l.to_ascii_lowercase();
+        if lower.starts_with("@prefix") || lower.starts_with("@base") {
+            return Some((ResourceType::RDF, Some(oxrdfio::RdfFormat::Turtle)));
+        }
+        if l.starts_with('<') && !l.starts_with("<?") && !l.starts_with("<!") && l.contains("> <") {
+            return Some((ResourceType::RDF, Some(oxrdfio::RdfFormat::Turtle)));
+        }
+        if l.starts_with("Prefix:") || l.starts_with("Ontology:") {
+            return Some((ResourceType::OMN, None));
+        }
+        if l.starts_with("Prefix(") || l.starts_with("Ontology(") {
+            return Some((ResourceType::OFN, None));
+        }
+        break;
+    }
+    None
+}
+
+fn first_xml_element(s: &str) -> Option<&str> {
+    let mut rest = s;
+    loop {
+        let lt = rest.find('<')?;
+        rest = &rest[lt..];
+        if rest.starts_with("<?") {
+            rest = &rest[rest.find("?>")? + 2..];
+            continue;
+        }
+        if rest.starts_with("<!--") {
+            rest = &rest[rest.find("-->")? + 3..];
+            continue;
+        }
+        if rest.starts_with("<!") {
+            rest = &rest[rest.find('>')? + 1..];
+            continue;
+        }
+        let name = rest[1..]
+            .split(|c: char| c.is_whitespace() || c == '>' || c == '/')
+            .next()?;
+        return Some(name);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{os::unix::fs::PermissionsExt, path::PathBuf};
+
+    #[test]
+    fn detect_format_rdf_xml() {
+        let (rt, fmt) = super::detect_format(b"<?xml version=\"1.0\"?>\n<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">").unwrap();
+        assert!(matches!(rt, super::ResourceType::RDF));
+        assert_eq!(fmt, Some(oxrdfio::RdfFormat::RdfXml));
+    }
+
+    #[test]
+    fn detect_format_owl_xml() {
+        let (rt, fmt) = super::detect_format(
+            b"<?xml version=\"1.0\"?>\n<Ontology xmlns=\"http://www.w3.org/2002/07/owl#\">",
+        )
+        .unwrap();
+        assert!(matches!(rt, super::ResourceType::OWX));
+        assert_eq!(fmt, None);
+    }
+
+    #[test]
+    fn detect_format_turtle() {
+        let (rt, fmt) =
+            super::detect_format(b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n").unwrap();
+        assert!(matches!(rt, super::ResourceType::RDF));
+        assert_eq!(fmt, Some(oxrdfio::RdfFormat::Turtle));
+    }
+
+    #[test]
+    fn detect_format_ntriples() {
+        let (rt, fmt) =
+            super::detect_format(b"<http://ex/s> <http://ex/p> <http://ex/o> .\n").unwrap();
+        assert!(matches!(rt, super::ResourceType::RDF));
+        assert_eq!(fmt, Some(oxrdfio::RdfFormat::Turtle));
+    }
+
+    #[test]
+    fn detect_format_ofn() {
+        let (rt, fmt) =
+            super::detect_format(b"Prefix(:=<http://ex/>)\nOntology(<http://ex/o>)").unwrap();
+        assert!(matches!(rt, super::ResourceType::OFN));
+        assert_eq!(fmt, None);
+    }
+
+    #[test]
+    fn detect_format_omn() {
+        let (rt, fmt) =
+            super::detect_format(b"Prefix: : <http://ex/>\nOntology: <http://ex/o>").unwrap();
+        assert!(matches!(rt, super::ResourceType::OMN));
+        assert_eq!(fmt, None);
+    }
+
+    #[test]
+    fn detect_format_bom_and_comments() {
+        let (rt, _) = super::detect_format("\u{feff}Ontology: <http://ex/o>".as_bytes()).unwrap();
+        assert!(matches!(rt, super::ResourceType::OMN));
+
+        let (rt, _) = super::detect_format(b"# a comment\n@prefix : <http://ex/> .").unwrap();
+        assert!(matches!(rt, super::ResourceType::RDF));
+    }
+
+    #[test]
+    fn detect_format_unknown() {
+        assert!(super::detect_format(b"format-version: 1.4\n[Term]").is_none());
+    }
 
     #[test]
     fn omn_parser_output_constructs_and_decomposes() {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -22,6 +22,38 @@ pub enum ResourceType {
     OMN,
 }
 
+/// The input format to use when parsing an ontology file.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum InputFormat {
+    /// Detect the format from file content, ignoring the extension.
+    Guess,
+    OFN,
+    OWX,
+    OMN,
+    /// An RDF-family format. `None` means detect the sub-format from the
+    /// extension; `Some` pins a specific serialization.
+    Rdf(Option<oxrdfio::RdfFormat>),
+}
+
+impl std::str::FromStr for InputFormat {
+    type Err = ();
+
+    /// Accepts `"guess"`, `"ofn"`, `"owx"`, `"omn"`, and any extension
+    /// recognised by [`oxrdfio::RdfFormat::from_extension`] plus `"owl"`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "guess" => Ok(Self::Guess),
+            "ofn" => Ok(Self::OFN),
+            "owx" => Ok(Self::OWX),
+            "omn" => Ok(Self::OMN),
+            "owl" => Ok(Self::Rdf(Some(oxrdfio::RdfFormat::RdfXml))),
+            other => oxrdfio::RdfFormat::from_extension(other)
+                .map(|f| Self::Rdf(Some(f)))
+                .ok_or(()),
+        }
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 pub enum ParserOutput<A: ForIRI, AA: ForIndex<A>> {
     OFNParser(SetOntology<A>, PrefixMapping),
@@ -31,6 +63,15 @@ pub enum ParserOutput<A: ForIRI, AA: ForIndex<A>> {
 }
 
 impl<A: ForIRI, AA: ForIndex<A>> ParserOutput<A, AA> {
+    pub fn resource_type(&self) -> ResourceType {
+        match self {
+            ParserOutput::OFNParser(..) => ResourceType::OFN,
+            ParserOutput::OWXParser(..) => ResourceType::OWX,
+            ParserOutput::RDFParser(..) => ResourceType::RDF,
+            ParserOutput::OMNParser(..) => ResourceType::OMN,
+        }
+    }
+
     pub fn ofn(sop: (SetOntology<A>, PrefixMapping)) -> ParserOutput<A, AA> {
         ParserOutput::OFNParser(sop.0, sop.1)
     }
@@ -74,6 +115,9 @@ pub struct ParserConfiguration {
     pub local_only: bool,
     pub rdf: RDFParserConfiguration,
     pub owx: OWXParserConfiguration,
+    /// Override format detection. When set, this takes precedence over the
+    /// file extension. `InputFormat::Guess` triggers content sniffing.
+    pub input_format: Option<InputFormat>,
 }
 
 impl Default for ParserConfiguration {
@@ -84,6 +128,7 @@ impl Default for ParserConfiguration {
             local_only: false,
             rdf: RDFParserConfiguration::default(),
             owx: OWXParserConfiguration::default(),
+            input_format: None,
         }
     }
 }


### PR DESCRIPTION
Closes #203.

- Adds `InputFormat` enum and `input_format` field on `ParserConfiguration` to override extension-based format detection
- `--input-format <FORMAT>` global CLI option accepting `guess`, `ofn`, `owx`, `omn`, `owl`, and any oxrdfio-recognised extension (`ttl`, `nt`, …)
- `horned-summary` now prints detected format at the end of output as human-readable name and MIME type
- Detection logic (already landed in the previous commit on this branch) adapted from micheldumontier/horned-roundtrip (MIT)