### PR TITLE
Fix clippy warnings hidden from bench/test targets; extend gate to --all-targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
         args: ["--check", "--"]
         pass_filenames: false
     -   id: clippy
+        args: ["--workspace", "--all-targets"]
         pass_filenames: false
 -   repo: local
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ triples-round-all:
 	done
 
 clippy:
-	cargo clippy
+	cargo clippy --workspace --all-targets
 
 install:
 	cargo install --path horned-bin

--- a/benches/io_read.rs
+++ b/benches/io_read.rs
@@ -58,7 +58,6 @@ fn bench_io_read(c: &mut Criterion) {
                     ParserConfiguration {
                         rdf: RDFParserConfiguration {
                             format: Some(oxrdfio::RdfFormat::Turtle),
-                            ..Default::default()
                         },
                         ..Default::default()
                     },

--- a/benches/iteration.rs
+++ b/benches/iteration.rs
@@ -85,8 +85,8 @@ fn family_to_vec() -> Vec<u8> {
     std::fs::read("./dev/family.owl").unwrap()
 }
 
-fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &Vec<u8>, b: Build<A>) -> ConcreteRDFOntology<A, AA> {
-    let mut c = Cursor::new(v.clone());
+fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &[u8], b: Build<A>) -> ConcreteRDFOntology<A, AA> {
+    let mut c = Cursor::new(v.to_owned());
     horned_owl::io::rdf::reader::read_with_build(&mut c, &b, Default::default())
         .unwrap()
         .0

--- a/benches/model.rs
+++ b/benches/model.rs
@@ -288,8 +288,8 @@ fn food_to_vec() -> Vec<u8> {
     std::fs::read("./benches/ont/food.owl").unwrap()
 }
 
-fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &Vec<u8>, b: Build<A>) -> ConcreteRDFOntology<A, AA> {
-    let mut c = Cursor::new(v.clone());
+fn read_vec<A: ForIRI, AA: ForIndex<A>>(v: &[u8], b: Build<A>) -> ConcreteRDFOntology<A, AA> {
+    let mut c = Cursor::new(v.to_owned());
     horned_owl::io::rdf::reader::read_with_build(&mut c, &b, Default::default())
         .unwrap()
         .0

--- a/horned-pretty-rdf/benches/pretty_rdf_bench.rs
+++ b/horned-pretty-rdf/benches/pretty_rdf_bench.rs
@@ -162,11 +162,7 @@ fn bench_owl_format(c: &mut Criterion) {
     for (name, src) in files {
         let triples = parse_owl(src);
         group.bench_function(*name, |b| {
-            b.iter_batched(
-                || triples.clone(),
-                |t| format_triples(t),
-                BatchSize::SmallInput,
-            )
+            b.iter_batched(|| triples.clone(), format_triples, BatchSize::SmallInput)
         });
     }
     group.finish();

--- a/horned-pretty-rdf/src/lib.rs
+++ b/horned-pretty-rdf/src/lib.rs
@@ -1482,14 +1482,10 @@ mod test {
             object: NamedNodeRef::new_unchecked("http://example.com/foo").into(),
         }
         .into();
-
-        assert!(true);
     }
 
     #[test]
-    pub fn chunk_hello_world() {
-        assert!(true)
-    }
+    pub fn chunk_hello_world() {}
 
     #[test]
     pub fn simple_chunk() {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -408,7 +408,7 @@ mod tests {
 
         if !output.status.success() {
             let out = String::from_utf8(output.stdout).unwrap();
-            assert!(false, "Bubo reparse failed: {out}");
+            panic!("Bubo reparse failed: {out}");
         }
 
         remove_dir_all(&tmp_dir)?;

--- a/src/io/omn/reader/from_pair.rs
+++ b/src/io/omn/reader/from_pair.rs
@@ -3403,9 +3403,10 @@ mod tests {
 
         let mut o = SetOntology::new_rc();
         // ontology header
-        let mut oid = OntologyID::default();
-        oid.iri = Some(b.iri("http://ex/onto"));
-        o.insert(oid);
+        o.insert(OntologyID {
+            iri: Some(b.iri("http://ex/onto")),
+            ..Default::default()
+        });
         // declarations
         for c in ["A", "B", "C", "D"] {
             o.insert(DeclareClass(b.class(format!("http://ex/{c}"))));
@@ -3582,9 +3583,10 @@ mod tests {
             .unwrap();
 
         let mut o = SetOntology::new_rc();
-        let mut oid = OntologyID::default();
-        oid.iri = Some(b.iri("http://ex/o"));
-        o.insert(oid);
+        o.insert(OntologyID {
+            iri: Some(b.iri("http://ex/o")),
+            ..Default::default()
+        });
         // an import too — validates the conformant header hosts iri+import+annotations together
         o.insert(Import(b.iri("http://ex/imported")));
         o.insert(OntologyAnnotation(Annotation {
@@ -3851,9 +3853,10 @@ mod tests {
         let mut o = SetOntology::new_rc();
 
         // ontology header
-        let mut oid = OntologyID::default();
-        oid.iri = Some(b.iri("http://ex/onto"));
-        o.insert(oid);
+        o.insert(OntologyID {
+            iri: Some(b.iri("http://ex/onto")),
+            ..Default::default()
+        });
 
         // Import
         o.insert(Import(b.iri("http://ex/imported")));
@@ -3955,9 +3958,10 @@ mod tests {
         pm.add_prefix("", "http://ex/").unwrap(); // default prefix → bare names
 
         let mut o = SetOntology::new_rc();
-        let mut oid = OntologyID::default();
-        oid.iri = Some(b.iri("http://ex/o"));
-        o.insert(oid);
+        o.insert(OntologyID {
+            iri: Some(b.iri("http://ex/o")),
+            ..Default::default()
+        });
         o.insert(DeclareClass(b.class("http://ex/Ancestor")));
         o.insert(DeclareClass(b.class("http://ex/Person")));
         o.insert(SubClassOf {
@@ -3995,10 +3999,10 @@ mod tests {
         let mut pm = PrefixMapping::default();
         pm.add_prefix("ex", "http://ex/").unwrap();
         let mut o = SetOntology::new_rc();
-        let mut oid = OntologyID::default();
-        oid.iri = Some(b.iri("http://ex/o"));
-        oid.viri = Some(b.iri("http://ex/o/1.0.0"));
-        o.insert(oid);
+        o.insert(OntologyID {
+            iri: Some(b.iri("http://ex/o")),
+            viri: Some(b.iri("http://ex/o/1.0.0")),
+        });
         o.insert(DeclareClass(b.class("http://ex/A")));
         type TestOnt = ComponentMappedOntology<
             std::rc::Rc<str>,
@@ -4033,9 +4037,10 @@ mod tests {
         let mut pm = PrefixMapping::default();
         pm.add_prefix("ex", "http://ex/").unwrap();
         let mut o = SetOntology::new_rc();
-        let mut oid = OntologyID::default();
-        oid.iri = Some(b.iri("http://ex/o"));
-        o.insert(oid);
+        o.insert(OntologyID {
+            iri: Some(b.iri("http://ex/o")),
+            ..Default::default()
+        });
         o.insert(Import(b.iri("http://ex/i")));
         o.insert(DeclareClass(b.class("http://ex/A")));
         type TestOnt = ComponentMappedOntology<

--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -2439,7 +2439,7 @@ pub mod test {
                 }
             }
         } else {
-            assert!(false);
+            panic!();
         }
     }
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -2908,8 +2908,6 @@ o:C rdf:type owl:Class .
             Default::default(),
             oxrdfio::RdfFormat::Turtle,
         );
-
-        assert!(true);
     }
 
     #[test]

--- a/src/ontology/logically_equal.rs
+++ b/src/ontology/logically_equal.rs
@@ -121,7 +121,6 @@ mod test {
     #[test]
     fn cons() {
         let _lei = LogicallyEqualIndex::new_rc();
-        assert!(true);
     }
 
     #[test]

--- a/src/ontology/set.rs
+++ b/src/ontology/set.rs
@@ -299,7 +299,6 @@ mod test {
     #[test]
     fn test_ontology_cons() {
         let _ = SetOntology::new_rc();
-        assert!(true);
     }
 
     #[test]
@@ -498,7 +497,6 @@ mod test {
     #[test]
     fn test_index_cons() {
         let _ = SetIndex::new_rc();
-        assert!(true);
     }
 
     #[test]

--- a/src/visitor/immutable.rs
+++ b/src/visitor/immutable.rs
@@ -860,9 +860,7 @@ mod test {
     use std::io::BufRead;
 
     #[test]
-    fn it_works() {
-        assert!(true)
-    }
+    fn it_works() {}
 
     pub fn read_ok<R: BufRead>(bufread: &mut R) -> SetOntology<String> {
         let r = read_with_build(bufread, &Build::new_string(), Default::default());

--- a/src/visitor/mutable.rs
+++ b/src/visitor/mutable.rs
@@ -817,7 +817,6 @@ impl<A: ForIRI, V: VisitMut<A>> WalkMut<A, V> {
 }
 
 #[cfg(test)]
-
 mod test {
     use super::*;
     use crate::io::owx::reader::test::read_ok;
@@ -867,7 +866,7 @@ mod test {
                 assert_eq!(literal, &"fred".to_string());
             }
             _ => {
-                assert!(false);
+                panic!();
             }
         }
     }

--- a/tests/manchester/canonical.rs
+++ b/tests/manchester/canonical.rs
@@ -15,12 +15,12 @@
 //!
 //! A "missing" entry (in ofn-truth, absent from omn-candidate) can be:
 //! - **(a) Reshuffle noise** — balanced missing≈extra on equiv/disjoint/same axioms;
-//!    cancelled by using `nary_member_pairs` as the secondary signal.
+//!   cancelled by using `nary_member_pairs` as the secondary signal.
 //! - **(b) OWL-API Manchester lossiness** — ROBOT genuinely cannot serialise some
-//!    axioms in Manchester; they are absent from the .omn text.  One-sided missing,
-//!    not the reader's fault.
+//!   axioms in Manchester; they are absent from the .omn text.  One-sided missing,
+//!   not the reader's fault.
 //! - **(c) Genuine omn-reader gap** — axiom present in .omn text but dropped or
-//!    mangled by the horned-owl Manchester reader.  Also one-sided missing.
+//!   mangled by the horned-owl Manchester reader.  Also one-sided missing.
 //!
 //! The flat `canonical` diff cannot separate (b) from (c) without inspecting the
 //! .omn source text.  Report both; note whether the diffs are balanced (→ noise)

--- a/tests/manchester/constructs.rs
+++ b/tests/manchester/constructs.rs
@@ -890,10 +890,10 @@ fn dp_value_boolean_exact_literal() {
 
         // Find the SubClassOf axiom with a non-named filler.
         let found = ont.iter().find_map(|ac| {
-            if let Component::SubClassOf(SubClassOf { sup, .. }) = &ac.component {
-                if let ClassExpression::DataHasValue { dp: _, l } = sup {
-                    return Some(l.clone());
-                }
+            if let Component::SubClassOf(SubClassOf { sup, .. }) = &ac.component
+                && let ClassExpression::DataHasValue { dp: _, l } = sup
+            {
+                return Some(l.clone());
             }
             None
         });


### PR DESCRIPTION
Closes #193.

Fixes a backlog of pre-existing warnings that `cargo clippy` (plain) never surfaced because it excludes bench and test-only targets:

- `assert!(true)` in smoke tests → removed
- `assert!(false)` in "should not reach" branches → `panic!()`
- `&Vec<u8>` parameters → `&[u8]` in bench helpers
- Needless `..Default::default()` inside a struct literal that already specifies all fields
- Redundant closure `|t| f(t)` → `f` in horned-pretty-rdf bench
- `field_reassign_with_default` in OMN reader tests → inline struct literal
- Empty line after `#[cfg(test)]` attribute
- Doc list item overindented in `tests/manchester/canonical.rs`
- Collapsible nested `if let` in `tests/manchester/constructs.rs`

Also updates `make clippy` and the pre-commit clippy hook to pass `--workspace --all-targets` so this class of warning cannot silently accumulate again.