### PR TITLE
Fix two broken #[ignore]d tests (fixtures/paths)

### DIFF
--- a/horned-bin/tests/test_horned_materialize.rs
+++ b/horned-bin/tests/test_horned_materialize.rs
@@ -1,7 +1,7 @@
 use assert_cmd::cargo;
 use assert_cmd::prelude::*; // Add methods on commands
 use predicates::prelude::*; // Used for writing assertions
-use std::{path::Path, process::Command}; // Run programs
+use std::{fs, path::Path, process::Command}; // Run programs
 
 #[test]
 fn integration_run() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,20 +14,47 @@ fn integration_run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// ignore by default because it is requires network access
-
+// Ignored by default because it requires network access: it fetches the BFO
+// import (http://purl.obolibrary.org/obo/bfo.owl) referenced by the fixture.
+// Run explicitly with `cargo test -- --ignored integration_ont_with_bfo`.
 #[test]
 #[ignore]
 fn integration_ont_with_bfo() -> Result<(), Box<dyn std::error::Error>> {
+    // Stage the in-repo fixture into a fresh temp dir so the test is hermetic:
+    // no reliance on a hand-placed tmp/ fixture, and no pollution of the work
+    // tree (the previous version wrote bfo.owl into the shared tmp/ and never
+    // cleaned up, so it could only pass once).
+    let dir = std::env::temp_dir().join(format!("horned-materialize-{}", std::process::id()));
+    if dir.exists() {
+        fs::remove_dir_all(&dir)?;
+    }
+    fs::create_dir_all(&dir)?;
+
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("../src/ont/owl-rdf/ont-with-bfo.owl");
+    let ont = dir.join("ont-with-bfo.owl");
+    fs::copy(&fixture, &ont)?;
+
+    // The BFO import (http://purl.obolibrary.org/obo/bfo.owl) is localized
+    // relative to the input file's directory using horned-owl's "favored"
+    // scheme, which joins the full IRI path with underscores — so it
+    // materializes to <dir>/obo_bfo.owl. It must not exist before we run.
+    let bfo = dir.join("obo_bfo.owl");
+    let exists = predicate::path::exists();
+    assert!(
+        !exists.eval(bfo.as_path()),
+        "import file should not exist yet"
+    );
+
     let mut cmd = Command::new(cargo::cargo_bin!("horned-materialize"));
-
-    let predicate_fn = predicate::path::exists();
-    assert!(!predicate_fn.eval(Path::new("../tmp/bfo.owl")));
-
-    cmd.arg("../tmp/ont-with-bfo.owl");
+    cmd.arg(&ont);
     cmd.assert().success();
 
-    assert!(predicate_fn.eval(Path::new("../tmp/bfo.owl")));
+    assert!(
+        exists.eval(bfo.as_path()),
+        "materialize should have downloaded the BFO import to {}",
+        bfo.display()
+    );
 
+    fs::remove_dir_all(&dir)?;
     Ok(())
 }

--- a/tests/manchester/corpus.rs
+++ b/tests/manchester/corpus.rs
@@ -31,13 +31,22 @@ pub fn docker_available() -> bool {
 /// Corpus ontologies, absolute paths to RDF/XML sources readable by ROBOT.
 /// Ordered smallest → largest so failures in big ontologies don't hide small ones.
 ///
+/// The corpus directory is taken from the `HORNED_CORPUS_DIR` environment
+/// variable and is expected to contain `<name>.rdfxml` for each ontology below.
+/// When the variable is unset or the files are absent, this returns an empty
+/// vec and the dependent tests skip gracefully (see `docker_available` gating).
+///
 /// NOTE: doid (27 MB RDF/XML) is intentionally excluded — ROBOT's Manchester
 /// serialisation takes >2 minutes on it, exceeding the per-ontology ROBOT timeout.
 /// hp (73 MB RDF/XML) converts in ~12 s (ROBOT handles it efficiently).
 pub fn corpus_paths() -> Vec<PathBuf> {
+    let Some(dir) = std::env::var_os("HORNED_CORPUS_DIR") else {
+        return Vec::new();
+    };
+    let dir = PathBuf::from(dir);
     ["koala", "sio", "obi-core", "hp"]
         .iter()
-        .map(|n| PathBuf::from(format!("/data/dumontier/pymos/bench/data/{n}.rdfxml")))
+        .map(|n| dir.join(format!("{n}.rdfxml")))
         .filter(|p| p.exists())
         .collect()
 }
@@ -234,6 +243,14 @@ pub fn run_corpus() -> Vec<CorpusRow> {
 fn corpus_parses_or_documents_blocker() {
     if !docker_available() {
         eprintln!("SKIPPED A2: docker/ROBOT not available");
+        return;
+    }
+    if corpus_paths().is_empty() {
+        eprintln!(
+            "SKIPPED A2: no corpus fixtures found \
+             (set HORNED_CORPUS_DIR to a directory containing \
+             koala/sio/obi-core/hp .rdfxml)"
+        );
         return;
     }
     let rows = run_corpus();


### PR DESCRIPTION
Fixes the two broken `#[ignore]`d tests identified in #196.

## `integration_ont_with_bfo` (horned-bin)
Previously expected a fixture at `../tmp/ont-with-bfo.owl` that no longer exists, so it failed with `IOError(NotFound)` before ever exercising import materialization.

- Made hermetic: stages the in-repo fixture (`src/ont/owl-rdf/ont-with-bfo.owl`) into a fresh per-process temp dir, runs there, and cleans up. No reliance on a hand-placed `tmp/` fixture and no work-tree pollution (the old version wrote `bfo.owl` into the shared `tmp/` and never cleaned up, so it could only pass once).
- Fixed a latent wrong assertion: the BFO import (`http://purl.obolibrary.org/obo/bfo.owl`) localizes to **`obo_bfo.owl`** (underscore-joined IRI path), not `bfo.owl`. The old check never ran because the test died on the missing fixture first.
- Still `#[ignore]`d (requires network). Verified passing with a real BFO download.

## `corpus_parses_or_documents_blocker` (manchester conformance)
`corpus_paths()` hardcoded fixtures under `/data/dumontier/pymos/bench/data`, so off that machine the path list was empty and `assert!(!rows.is_empty())` panicked — a genuine assertion failure, not the graceful docker-absent skip the module doc claims.

- Read the corpus dir from `HORNED_CORPUS_DIR` instead of a hardcoded path; return empty when unset/absent.
- Skip the test gracefully (with a message) when no corpus is configured.
- `canonical.rs` needed no change — it already routes through `corpus::corpus_paths()` with an early-return guard, so the central fix covers it.

## Verification
- `integration_ont_with_bfo` — passes with `--ignored` (real network fetch).
- `corpus_parses_or_documents_blocker` — skips cleanly and passes (docker present, corpus absent).
- Default suites still green: `test_horned_materialize` (1 passed, 1 ignored), `manchester_conformance` (20 passed, 3 ignored).

Note: the corpus fixtures (`koala`, `sio`, `obi-core`, `hp`) are genuinely gone and not recoverable from the original machine, so making the path configurable is the right call rather than relocating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)