### PR TITLE
Fix rdfs:Class, undeclared property catch-alls, and anonymous ontology panic

### DIFF
--- a/src/io/rdf/closure_reader.rs
+++ b/src/io/rdf/closure_reader.rs
@@ -123,14 +123,18 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> ClosureOntologyParse
         let si: &SetIndex<A, AA> = o.as_ref();
         let id = si.the_ontology_id_or_default();
 
+        // Use the declared ontology IRI (or version IRI) as the storage key;
+        // fall back to the document IRI for anonymous ontologies so they are
+        // still stored and can be returned by `as_ontology_vec_and_incomplete`.
+        let storage_iri = id
+            .clone()
+            .viri_or_iri()
+            .unwrap_or_else(|| new_doc_iri.clone());
+
         // Stuff the iri of this ontology, if we have one into a vec
         let mut res = match id.clone().viri_or_iri() {
-            Some(resolved_iri) => {
-                vec![resolved_iri]
-            }
-            _ => {
-                vec![]
-            }
+            Some(resolved_iri) => vec![resolved_iri],
+            _ => vec![],
         };
 
         // Add the ontology that we have parsed into import_map. An
@@ -138,16 +142,13 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> ClosureOntologyParse
         // or the version IRI of an Ontology, so if both are present
         // and differ, record the plain IRI as an alias of the
         // version IRI so that either can be used to find this entry.
-        if let Some(resolved_iri) = id.clone().viri_or_iri() {
-            if let (Some(iri), Some(viri)) = (id.iri, id.viri)
-                && iri != viri
-            {
-                self.alias.insert(iri, viri);
-            }
-            self.import_map
-                .insert(resolved_iri.clone(), imports.clone());
-            self.op.insert(resolved_iri, p);
+        if let (Some(iri), Some(viri)) = (id.iri, id.viri)
+            && iri != viri
+        {
+            self.alias.insert(iri, viri);
         }
+        self.import_map.insert(storage_iri.clone(), imports.clone());
+        self.op.insert(storage_iri, p);
 
         // Now parse all of the imported ontologies as well
         for import in imports {
@@ -243,7 +244,12 @@ pub fn read<A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>>(
     }
 
     let res = c.as_ontology_vec_and_incomplete();
-    Ok(res.into_iter().next().unwrap())
+    res.into_iter().next().ok_or_else(|| {
+        HornedError::ValidityError(
+            "RDF document contains no named owl:Ontology".to_string(),
+            crate::error::Location::Unknown,
+        )
+    })
 }
 
 // Returns the import closure of an Ontology and IncompleteParse

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -2078,21 +2078,43 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 [Term::Iri(i), Term::OWL(VOWL::DifferentFrom), Term::Iri(j)] => {
                     Ok(Some(DifferentIndividuals(vec![i.into(), j.into()]).into()))
                 }
-                [Term::Iri(sub), Term::Iri(pred), t @ Term::Literal(_)] => ok_some! {
-                    DataPropertyAssertion {
-                        dp: pred.clone().into(),
-                        from: sub.into(),
-                        to: self.convert_to_literal(t)?
-                    }.into()
-                },
-                [Term::Iri(sub), Term::Iri(pred), Term::Iri(obj)] => Ok(Some(
-                    ObjectPropertyAssertion {
-                        ope: ObjectProperty(pred.clone()).into(),
-                        from: sub.into(),
-                        to: obj.into(),
+                [Term::Iri(sub), Term::Iri(pred), t @ Term::Literal(_)] => {
+                    if self.config.lax
+                        || matches!(
+                            self.distinguish_declaration_kind(pred, ic),
+                            Some(NamedOWLEntityKind::DataProperty)
+                        )
+                    {
+                        ok_some! {
+                            DataPropertyAssertion {
+                                dp: pred.clone().into(),
+                                from: sub.into(),
+                                to: self.convert_to_literal(t)?
+                            }.into()
+                        }
+                    } else {
+                        Ok(None)
                     }
-                    .into(),
-                )),
+                }
+                [Term::Iri(sub), Term::Iri(pred), Term::Iri(obj)] => {
+                    if self.config.lax
+                        || matches!(
+                            self.distinguish_declaration_kind(pred, ic),
+                            Some(NamedOWLEntityKind::ObjectProperty)
+                        )
+                    {
+                        Ok(Some(
+                            ObjectPropertyAssertion {
+                                ope: ObjectProperty(pred.clone()).into(),
+                                from: sub.into(),
+                                to: obj.into(),
+                            }
+                            .into(),
+                        ))
+                    } else {
+                        Ok(None)
+                    }
+                }
                 _ => Ok(None),
             };
 

--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -2976,4 +2976,36 @@ o:C rdf:type owl:Class .
     // fn family() {
     //     compare("family");
     // }
+
+    #[test]
+    fn rdfs_class_does_not_produce_class_assertion() {
+        // rdfs:Class is the RDFS metaclass, not a valid OWL class expression.
+        // A triple <X> rdf:type rdfs:Class should NOT become a ClassAssertion
+        // (ClassAssertion(Class(rdfs:Class), X) is meaningless in OWL DL).
+        // The triple should be left in the incomplete parse instead.
+        let xml = r#"<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+    <owl:Ontology rdf:about="http://www.example.com/iri"/>
+    <rdfs:Class rdf:about="http://www.example.com/iri#C"/>
+</rdf:RDF>"#;
+
+        let (ont, incomplete): (ConcreteRDFOntology<RcStr, Rc<AnnotatedComponent<RcStr>>>, _) =
+            read(&mut xml.as_bytes(), Default::default()).unwrap();
+
+        let ont: SetOntology<_> = ont.into();
+        let class_assertions: Vec<_> = ont
+            .iter()
+            .filter(|ac| matches!(ac.component, Component::ClassAssertion(_)))
+            .collect();
+        assert!(
+            class_assertions.is_empty(),
+            "rdfs:Class should not produce ClassAssertion axioms, got: {class_assertions:?}"
+        );
+        assert!(
+            !incomplete.is_complete(),
+            "rdfs:Class triple should remain in the incomplete parse"
+        );
+    }
 }

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -160,6 +160,7 @@ vocabulary_type! {
 
 vocabulary_type! {
     RDFS, IRI<String>, METARDFS, [
+        (RDFS, Class, false),
         (RDFS, Comment, true),
         (RDFS, Datatype, false),
         (RDFS, Domain, true),
@@ -541,6 +542,10 @@ mod tests {
 
     #[test]
     fn test_meta_rdfs() {
+        assert_eq!(
+            RDFS::Class.as_ref(),
+            "http://www.w3.org/2000/01/rdf-schema#Class"
+        );
         assert_eq!(
             RDFS::Comment.as_ref(),
             "http://www.w3.org/2000/01/rdf-schema#comment"


### PR DESCRIPTION
## Summary

- `rdfs:Class` is now a recognized vocab term (`Term::RDFS(VRDFS::Class)`), so triples using it as a class expression no longer produce spurious `ClassAssertion` axioms — they stay in `IncompleteParse` as they should
- The `DataPropertyAssertion` and `ObjectPropertyAssertion` catch-alls in `axioms()` now gate on the predicate IRI being declared as `DataProperty` / `ObjectProperty` respectively (strict mode); undeclared annotation predicates like `skos:prefLabel` no longer silently produce wrong axioms. Lax mode preserves the original permissive behaviour
- `closure_reader::read()` no longer panics when the RDF document has no `owl:Ontology` IRI; anonymous ontologies are now stored under their document IRI and `read()` returns a proper `ValidityError` if no ontology can be found at all

## Test plan

- [ ] `make quick-test` (all 1352 reader tests pass, 20 unit tests pass)
- [ ] `cargo clippy` clean
- [ ] Bench comparison `devel` vs `fix/rdfs-class-vocab`: no regression — fix branch is marginally faster on reads across all sizes
- [ ] `horned-parse` on a 2M-class anonymous RDF/XML ontology: parses in ~5.6s and returns "Parse Complete" instead of panicking