### PR TITLE
Report horned-owl version in horned-bin --version output

### DIFF
--- a/horned-bin/src/bin/horned.rs
+++ b/horned-bin/src/bin/horned.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), HornedError> {
 fn app() -> App<'static> {
     horned_bin::config::parser_app_global(
         App::new("horned")
-            .version("0.3")
+            .version(horned_bin::version_string())
             .about("Command Line tools for OWL Ontologies")
             .author("Filippo De Bortoli <filippo.de_bortoli@tu-dresden.de>,\nPhillip Lord <phillip.lord@newcastle.ac.uk ")
             .subcommand_required(true)

--- a/horned-bin/src/bin/horned_big.rs
+++ b/horned-bin/src/bin/horned_big.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Generate a big OWL file for testing")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_compare.rs
+++ b/horned-bin/src/bin/horned_compare.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Compare two OWL files")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_convert.rs
+++ b/horned-bin/src/bin/horned_convert.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Convert an OWL Ontology between formats")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_dump.rs
+++ b/horned-bin/src/bin/horned_dump.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Parse an OWL File and dump the data structures")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_materialize.rs
+++ b/horned-bin/src/bin/horned_materialize.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Parse an OWL file and download all the imports.")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_parse.rs
+++ b/horned-bin/src/bin/horned_parse.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Parse an OWL File")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_round.rs
+++ b/horned-bin/src/bin/horned_round.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Parse and Render an OWL Ontology")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_summary.rs
+++ b/horned-bin/src/bin/horned_summary.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Summary Statistics for an OWL file.")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_triples.rs
+++ b/horned-bin/src/bin/horned_triples.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Parse RDF and dump the triples")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_unparsed.rs
+++ b/horned-bin/src/bin/horned_unparsed.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Show unparsed OWL RDF.")
         .author("Phillip Lord")
         .arg(

--- a/horned-bin/src/bin/horned_validate.rs
+++ b/horned-bin/src/bin/horned_validate.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), HornedError> {
 
 pub(crate) fn app(name: &str) -> App<'static> {
     App::new(name)
-        .version("0.1")
+        .version(horned_bin::version_string())
         .about("Validates an ontology against the OWL2 specification")
         .author("Filippo De Bortoli")
         .arg(

--- a/horned-bin/src/lib.rs
+++ b/horned-bin/src/lib.rs
@@ -27,6 +27,22 @@ pub mod error {
     }
 }
 
+/// This binary's version, combined with the horned-owl library version it
+/// was compiled against -- e.g. `"2.0.0 (horned-owl 2.0.0)"`. Used as the
+/// `clap::App::version` for every horned-bin binary so `--version` reports
+/// something meaningful instead of a stale hardcoded literal (see
+/// https://github.com/phillord/horned-owl/issues/219).
+pub fn version_string() -> &'static str {
+    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    VERSION.get_or_init(|| {
+        format!(
+            "{} (horned-owl {})",
+            env!("CARGO_PKG_VERSION"),
+            horned_owl::VERSION
+        )
+    })
+}
+
 /// The `oxrdfio::RdfFormat` that `extension` denotes, if any. `"owl"`
 /// is horned-owl's own long-standing alias for RDF/XML; every other
 /// extension is whatever [`oxrdfio::RdfFormat::from_extension`]

--- a/horned-bin/tests/test_horned.rs
+++ b/horned-bin/tests/test_horned.rs
@@ -59,3 +59,35 @@ fn integration_local_only_not_available_on_standalone_binary()
 
     Ok(())
 }
+
+#[test]
+fn integration_version_reports_horned_owl_version() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("horned"));
+    cmd.arg("--version");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("horned-owl"))
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+
+    Ok(())
+}
+
+#[test]
+fn integration_version_reports_on_standalone_binary_and_subcommand()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut standalone = Command::new(cargo::cargo_bin!("horned-parse"));
+    standalone.arg("--version");
+    standalone
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("horned-owl"));
+
+    let mut subcommand = Command::new(cargo::cargo_bin!("horned"));
+    subcommand.arg("big").arg("--version");
+    subcommand
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("horned-owl"));
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,8 @@ pub mod ontology;
 pub mod resolve;
 pub mod visitor;
 pub mod vocab;
+
+/// The version of this horned-owl library crate, baked in at compile
+/// time. Exposed so consumers (notably the `horned-bin` CLIs) can report
+/// exactly which horned-owl source a binary was compiled from.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
## Summary

Closes #219. Every horned-bin binary's `--version` output was a hardcoded literal (`"0.1"` for the 11 standalone binaries, `"0.3"` for the unified `horned`), unrelated to `CARGO_PKG_VERSION` and long stale -- both crates are actually at `2.0.0`.

- `horned-owl` gains `pub const VERSION: &str = env!("CARGO_PKG_VERSION")` in `src/lib.rs`.
- `horned-bin` gains a `version_string()` helper (`horned-bin/src/lib.rs`) combining its own `CARGO_PKG_VERSION` with `horned_owl::VERSION`, e.g. `"2.0.0 (horned-owl 2.0.0)"`.
- All 12 `horned-bin/src/bin/*.rs` binaries now use `.version(horned_bin::version_string())` instead of the hardcoded literal.

No `build.rs` needed -- `Cargo.lock` isn't checked into this repo and there's no existing `build.rs` precedent in the workspace, so a compile-time `pub const` re-export is the simplest fix that works identically for local path-dependency dev builds and published-crate installs.

**Known limitation** (not addressed here, flagged as a possible follow-up): since horned-owl/horned-bin only bump version numbers together at release time, two different `devel` checkouts between releases will report identical `--version` output. This wouldn't have caught the specific stale-binary incident that prompted #219 (an older `devel` checkout vs. a newer one, same unreleased version). Actually solving that needs a git-SHA embedded via `build.rs` (e.g. `vergen`/`built`) -- a separate, larger change, out of scope here.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --lib --bins --tests -- --skip integration` -- all passing
- [x] `cargo fmt --check` / `cargo clippy --all-targets` -- clean
- [x] Manual check: `horned --version`, `horned big --version`, `horned-parse --version` all report `<bin> <version> (horned-owl <version>)`
- [x] New tests: `integration_version_reports_horned_owl_version`, `integration_version_reports_on_standalone_binary_and_subcommand` (`horned-bin/tests/test_horned.rs`)