### PR TITLE
Remove redundant ForIRI bound from Build's struct declaration

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -276,7 +276,7 @@ impl<A: ForIRI> IRI<A> {
 /// different instances can be combined within a single ontology
 /// without consequences except for increased memory use.
 #[derive(Debug, Default)]
-pub struct Build<A: ForIRI>(
+pub struct Build<A>(
     RefCell<BTreeSet<IRI<A>>>,
     RefCell<BTreeSet<AnonymousIndividual<A>>>,
     // Last anon individual


### PR DESCRIPTION
## Summary
- `Build<A: ForIRI>`'s struct-level bound was redundant: every `impl` block on `Build` already carries `impl<A: ForIRI> Build<A>`, and Rust doesn't require bounds on a struct declaration for methods to use them.
- Removes the bound from the declaration only; no other API or behavior changes.

Closes #74

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --lib --bins --tests -- --skip integration`