### PR TITLE
Add horned-macro: write Manchester and Functional syntax in Rust (omn!, ofn!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ oxrdfio={workspace=true}
 ureq={version="3.3.0", optional=true}
 
 [workspace]
-members=["horned-bin", "horned-pretty-rdf", "horned-catalog"]
-default-members=[".", "horned-bin", "horned-pretty-rdf", "horned-catalog"]
+members=["horned-bin", "horned-pretty-rdf", "horned-catalog", "horned-macro"]
+default-members=[".", "horned-bin", "horned-pretty-rdf", "horned-catalog", "horned-macro"]
 
 [workspace.dependencies]
 indexmap="1.0.2"
@@ -41,6 +41,7 @@ mktemp="0.5.1"
 oxiri="0.2.11"
 horned-pretty-rdf={path="./horned-pretty-rdf", version="2.0.0"}
 horned-catalog={path="./horned-catalog", version="0.1.0"}
+horned-macro={path="./horned-macro", version="0.1.0"}
 oxrdf="0.3.0"
 oxrdfio="0.2.0"
 
@@ -58,6 +59,7 @@ pretty_assertions = "1.0.0"
 slurp = "1.0.1"
 rstest = "0.23"
 horned-bin = {path="horned-bin"}
+horned-macro = {workspace = true}
 
 [profile.release]
 debug = true

--- a/docs/horned-macro-plan.md
+++ b/docs/horned-macro-plan.md
@@ -1,0 +1,275 @@
+# `horned-macro`: write Manchester syntax directly in Rust
+
+## Problem
+
+Constructing an `Ontology`/`Component` tree by hand in Rust (test fixtures, inline example
+ontologies, small embedded ontology snippets in application code) means writing out
+`Build`/`SubClassOf { sup: ..., sub: ... }`/`b.class(...)` calls verbatim, which is verbose and
+far removed from how anyone actually thinks about OWL. `horned-owl` already has two full,
+well-tested textual syntaxes (Manchester Syntax and OWL Functional Syntax) — the goal here is to
+let those be written directly in Rust source as a macro literal, e.g.:
+
+```rust
+let onto: SetOntology<RcStr> = omn!(&b, "
+    Prefix: : <http://example.org/>
+    Class: Foo
+    Class: Bar
+        SubClassOf: Foo
+");
+```
+
+with syntax errors reported as *Rust compile errors*, at the macro invocation site, not as a
+runtime panic three test-runs later.
+
+## Design decision: compile-time syntax check, runtime construction — not a from-scratch engine
+
+The tempting design is "parse Manchester into `Component`s entirely inside the proc-macro, at
+compile time." This is a trap for this particular grammar: `horned-owl`'s Manchester reader
+(`src/io/omn/reader/`) is not a pure grammar→AST transform. It does real semantic work — a
+declaration pre-pass that disambiguates data vs. object properties, HasKey key typing, and more
+(see the extensive module-doc "Supported §2.5 surface" / "Residual constructs" notes in
+`src/io/omn/reader/mod.rs`). Re-implementing that inside a proc-macro, which runs in a separate
+compilation context with no access to a real `Build<A>` (IRI interning is inherently a *runtime*
+concern — `A` isn't even known at macro-expansion time; it's whatever the call site's `Build`
+happens to be instantiated with), would mean either duplicating a large, actively-evolving piece
+of semantic logic, or reinventing IRI interning at compile time for no reason. Both are a bad
+trade for a first version.
+
+Instead: `horned-macro` depends on `horned-owl` directly (proc-macro crates can depend on regular
+crates freely — only the reverse is forbidden) and reuses two things that are *already* cleanly
+separated in the existing reader:
+
+1. **`horned_owl::io::omn::reader::{ManchesterLexer, Rule}`** — the pure `pest` grammar parse
+   step (`ManchesterLexer::lex(Rule::ManchesterDocument, text)`), already public, already used
+   internally exactly this way before the semantic passes run. This takes a plain `&str` and
+   needs no `Build`, no IRI type, nothing runtime — perfect for compile time. Calling this from
+   the proc-macro against the string literal's contents is the entire "compile-time check."
+2. **`horned_owl::io::omn::reader::read_with_build`** — the existing, fully-tested runtime
+   reader. The macro's expansion is just a call into this, with the caller's `Build` and the
+   embedded string. All the semantic complexity above stays exactly where it already is, single
+   source of truth, zero drift between "what the macro accepts" and "what the real reader
+   accepts" (impossible for them to disagree, since it's the same code).
+
+This is the same shape as `sqlx::query!`: real compile-time verification against the real grammar
+(so typos are caught early, with a real Rust compile error), but the actual construction still
+happens at runtime through the already-correct, already-tested machinery. It is a small amount of
+new code — a proc-macro that extracts a string literal, calls an existing pure function on it,
+and emits a call to another existing function — not a new parser.
+
+**Trade-off, stated plainly:** this catches *syntax* errors at compile time but not *semantic*
+ones (e.g. a HasKey data/object key ambiguity) — those still only surface at runtime, as a panic
+from the macro's expansion (see API sketch). Given how rarely the semantic passes reject
+something the grammar accepts, this is expected to be the overwhelming common case caught, for a
+fraction of the engineering cost of a full compile-time semantic engine. Worth revisiting only if
+it proves to be a real gap in practice.
+
+## Detour: unquoted tokens, tried and reverted
+
+An unquoted calling convention was tried and shipped briefly, then reverted back to the quoted
+string shown above. Worth keeping this section rather than deleting it: the empirical findings
+below are real and would resurface if unquoted tokens are ever tried again, and the reason for
+reverting is a real design conclusion, not just a preference flip.
+
+The idea: drop the surrounding string entirely, e.g.
+`omn!(&b, Prefix: ex = "http://example.org/" Class: ex:Foo Class: ex:Bar SubClassOf: ex:Foo)`.
+The design above (compile-time check + runtime construction via the real reader) survived intact
+under this convention too -- only the input-parsing/reassembly step changed. Two hard constraints,
+found empirically (not guessed), shaped what that version had to look like:
+
+1. **A full `<http://...>` IRI can never appear as bare (unquoted) macro tokens.** Rust's own
+   lexer strips `//` as a line comment *before any macro -- proc or `macro_rules!` -- ever sees a
+   token stream*; this happens at the compiler's tokenizer stage, upstream of all macro expansion.
+   Confirmed directly: `show!(Prefix: : <http://example.org/> Class: Foo)` through a trivial
+   `macro_rules!` doesn't just mis-tokenize the IRI, it eats the rest of the line -- including the
+   macro's own closing `)` and the following `;` -- producing a "mismatched closing delimiter"
+   error. There is no proc-macro-side workaround; the only way content survives Rust's tokenizer
+   with `//` intact is inside a string (or raw string) literal, because string contents are
+   captured verbatim, never re-tokenized.
+
+   Consequence: `omn!` cannot accept a bare `<http://...>` IRI anywhere. The one remaining quoted
+   piece is a `Prefix: name = "iri"` declaration's IRI string; every entity reference after that
+   is a bare CURIE (`ex:Foo`), which real Manchester documents mostly use anyway once prefixes are
+   declared.
+
+2. **`proc_macro2::TokenStream::to_string()` inserts a space around every token, including `:`,**
+   turning `ex:Foo` into `ex : Foo` on reconstruction -- which the grammar rejects, since a CURIE
+   (`prefix:LocalName`), a frame keyword (`Class:`, `SubClassOf:`, ...), and a blank node (`_:id`)
+   are all lexed as a single unit with **no** whitespace around their `:`. (This is *not* the same
+   spacing behaviour as the compiler-builtin `stringify!` macro, which happened to preserve
+   `ex:Foo` with no space in an isolated test -- the two have different, non-interchangeable
+   pretty-printing rules; don't assume one behaves like the other.) Fixed by writing a small
+   custom re-stringifier (`stringify_tokens` in `horned-macro/src/lib.rs`) instead of using
+   `TokenStream`'s own `Display`: it never inserts a space immediately before or after a `:`
+   token, and otherwise respects Rust's own `Punct::spacing()` `Joint` hint (needed so a literal's
+   `^^datatype` suffix -- two adjacent `^` tokens -- doesn't get split apart either). Verified
+   against the real grammar via `ManchesterLexer::lex`, not assumed.
+
+That token-parsing/reassembly version worked, was fully tested (including the `trybuild`
+negative case, still passing), and was briefly the shipped design. **Reverted anyway.** The
+reason: the CURIE-only restriction it required isn't a minor ergonomic wrinkle, it's a scope cut
+that stops the macro from being a Manchester Syntax macro at all -- you categorically cannot
+write a full `<http://...>` IRI in it, anywhere, ever, on stable Rust. That's a real subset of
+the real grammar permanently out of reach, for the sake of dropping one pair of quote marks. The
+quoted-string version has no such restriction: the *entire* §2.5 grammar `read_with_build`
+supports is available, unrestricted, because the text never has to survive Rust's tokenizer at
+all -- it's opaque string contents. "No quotes" reads nicer at the call site, but "not actually
+Manchester syntax" is the wrong trade for what this macro is for.
+
+## Scope
+
+`omn!` (Manchester Syntax) and `ofn!` (OWL Functional Syntax) — named after the file extension
+each format already uses elsewhere in this repo (`.omn`, `.ofn`), matching how the request to add
+functional syntax support was framed ("we can use the file name extension as the macro name").
+`ofn!` followed `omn!` in the same session once the design settled, since the OFN reader has
+exactly the same shape as Manchester's: a `pest` grammar (`src/grammars/ofn.pest`) plus a
+semantic pass, cleanly separated the same way. The only `horned-owl`-side change `ofn!` needed
+was widening `src/io/ofn/reader/mod.rs`'s `mod lexer;`/private `use` to `pub mod lexer;`/`pub use`
+-- `OwlFunctionalLexer`/`Rule` weren't previously exported the way Manchester's already were.
+
+Both macros take a full document (prefixes/imports plus one or more
+frames/axioms — the same thing each format's `io::*::reader::read` accepts), not a single bare
+axiom or class expression. This is the broadest-leverage form: it reuses `read_with_build`
+exactly as-is, and covers the main use case (test fixtures, small embedded ontologies) directly. A
+finer-grained `omn_class!`/`omn_axiom!` for a single expression is plausible future work (noted
+below), not v1.
+
+**Considered and rejected: `include_str!("file.omn")` support.** Since `omn!`/`ofn!` are
+function-like proc-macros, they always receive raw, unexpanded tokens -- a nested `include_str!`
+call is never pre-resolved before they see it (confirmed directly: passing one to the `LitStr`
+parser fails with "expected string literal"). It's possible to work around this: detect
+`include_str!(...)` syntactically, read the file directly inside the proc-macro's own process
+(ordinary, non-const code — heap allocation is completely fine there), resolving a relative path
+against the calling file's own directory via the now-stable `Span::local_file()`. This was built
+and confirmed working (a real bubo-generated `.omn` file, checked at compile time, embedded into
+the binary) — then deliberately not kept. It was built purely to answer "is this possible," not
+because the macro needed it; keeping bespoke path-resolution/file-reading logic in the macro for a
+convenience nobody asked to keep isn't worth the added surface area, especially since one real gap
+remains even in the working version: `proc_macro::tracked_path` (which would make Cargo rebuild
+when the included file changes, like the compiler's own `include_str!` does) isn't stable, so
+edits to the included file don't reliably trigger a rebuild. If this is wanted later, the
+implementation is straightforward to redo -- `resolve_text` in an earlier revision of
+`horned-macro/src/lib.rs` is the reference.
+
+**Considered and rejected: compile-time construction via `const fn`.** Not viable for two
+independent, both-fatal reasons, not just impractical: (1) `const` evaluation has no filesystem
+access at all, on stable or nightly, by design — this is exactly why `include_str!`/`include_bytes!`
+exist as special compiler builtins rather than being expressible in ordinary Rust; (2) even given
+the text already in hand, the actual `Ontology`/`Component` value can't be a `const` regardless,
+since `Build`'s IRI interning and `SetOntology`/`ComponentMappedOntology` are all
+heap-allocated (`Rc`, `HashSet`, `Vec`, `IndexMap`), and const evaluation cannot allocate on the
+heap on stable Rust -- confirmed directly: even a plain `Vec::push` inside a `const fn` fails to
+compile on the toolchain used here (rustc 1.97.0) with "not yet stable as a const fn". This is
+exactly why the compile-time half of `omn!`/`ofn!` only ever runs the pure syntax check (which
+happens in the proc-macro's own ordinary process, free to heap-allocate) and always defers actual
+construction to a generated runtime call -- a `const fn` could not do either half of what these
+macros do.
+
+## Public API sketch
+
+```rust
+// horned-macro/src/lib.rs
+
+/// Parse `$manchester_text` as a Manchester Syntax document at compile time
+/// (a real Rust compile error if it doesn't parse), and expand to code that
+/// constructs the ontology at runtime via `$build`.
+///
+/// `$build` must be a `&Build<A>` for whatever `A: ForIRI` the surrounding
+/// code is using. The expression's type is inferred the normal way from
+/// context (e.g. a `let` binding's type annotation), exactly as if you'd
+/// called `horned_owl::io::omn::reader::read_with_build` yourself.
+///
+/// # Panics
+/// If the embedded text passes the compile-time syntax check but the
+/// runtime semantic reader still rejects it (rare -- see
+/// docs/horned-macro-plan.md's "Design decision" section) or errors for an
+/// unrelated reason (e.g. an unresolvable prefix), the expansion panics
+/// with the underlying `HornedError`'s message. This is a deliberate v1
+/// simplification (see "Open questions" below) rather than forcing every
+/// call site to unwrap a `Result` for what's meant to be an inline literal.
+#[proc_macro]
+pub fn omn(input: TokenStream) -> TokenStream { .. }
+```
+
+Usage:
+
+```rust
+use horned_owl::model::{Build, RcStr};
+use horned_owl::ontology::set::SetOntology;
+use horned_macro::omn;
+
+let b: Build<RcStr> = Build::new_rc();
+let onto: SetOntology<RcStr> = omn!(&b, "
+    Prefix: : <http://example.org/>
+    Class: Foo
+    Class: Bar
+        SubClassOf: Foo
+");
+```
+
+Expansion (conceptually — exact hygiene/temporary-naming TBD during implementation):
+
+```rust
+{
+    match ::horned_owl::io::omn::reader::read_with_build(
+        "Prefix: : <http://example.org/>\nClass: Foo\n...".as_bytes(),
+        &b,
+    ) {
+        ::std::result::Result::Ok((onto, _prefixes)) => onto,
+        ::std::result::Result::Err(e) => panic!(
+            "horned-macro: `omn!` passed its compile-time syntax check but failed at \
+             runtime construction ({e}) -- this means the text is syntactically valid \
+             Manchester but semantically rejected; see docs/horned-macro-plan.md"
+        ),
+    }
+}
+```
+
+## Phased implementation plan
+
+1. **Scaffold**: `horned-macro/Cargo.toml` (`[lib] proc-macro = true`), depending on `horned-owl`
+   (path dependency, matching how `horned-catalog`/`horned-pretty-rdf` are wired into the
+   workspace), `syn` (parsing the macro's own input: an expression, a comma, a string literal),
+   `quote` (codegen), `proc-macro2`. Wired into the workspace `members`/`default-members`.
+2. **Input parsing**: a small `syn::parse::Parse` impl for `(Expr, LitStr)` — the two
+   comma-separated macro arguments.
+3. **Compile-time check**: call `horned_owl::io::omn::reader::ManchesterLexer::lex(Rule::ManchesterDocument,
+   &lit_str.value())`. On `Err`, turn the `HornedError`'s message (it carries a byte
+   position/span via `Location` — see `src/error.rs`) into a `syn::Error` pointing at the string
+   literal's span (span-level sub-highlighting of *where inside* the string is a stable-Rust
+   limitation — see "Open questions"; v1 points at the whole literal and puts the byte/line
+   position in the message text instead) and return `.to_compile_error()`.
+4. **Codegen**: emit the expansion sketched above, using the original `Expr` for `$build` and the
+   string literal's value embedded as a Rust string literal (re-quoted, not re-parsed).
+5. **Tests**: proc-macro crates can't easily unit-test their own macro expansion in the same
+   crate; the standard pattern is a `tests/` integration test in `horned-macro` itself that
+   actually invokes `omn!` and asserts on the resulting `SetOntology`, plus a `trybuild`
+   dev-dependency `tests/ui/bad_syntax.rs` + matching `.stderr` proving a genuine syntax mistake
+   becomes a compile error, not a runtime panic — regenerated via `TRYBUILD=overwrite` and then
+   verified stable on a normal run.
+6. **`horned-owl` dev-dependency**: `horned-macro` added as a dev-dependency of `horned-owl`
+   itself (a dev-dependency cycle — fully supported by Cargo, verified working here), with one
+   illustrative smoke test (`tests/horned_macro_smoke.rs`) using `omn!` from within `horned-owl`'s
+   own test suite. Rewriting existing fixtures to use it is out of scope for this session.
+
+All six phases above are done and green (build/test/clippy/fmt clean across the whole workspace)
+as of this session. The unquoted-tokens detour (see above) was built, fully tested, and then
+reverted back to this design within the same session. `ofn!` was added afterwards, following
+exactly the same shape (own `MacroInput`/`expand` reuse in `horned-macro/src/lib.rs`, own
+`tests/ofn.rs` + `tests/ui/ofn_bad_syntax.rs`+`.stderr`), including its own `trybuild`
+negative case proving OFN syntax mistakes are compile errors too.
+
+## Open questions / deliberately deferred
+
+- **Sub-span error highlighting.** Pointing a compile error at the *exact character* inside a
+  multi-line string literal that has the syntax error (rather than underlining the whole literal)
+  needs `proc_macro::Span::subspan`, which is nightly-only as of this writing. V1 underlines the
+  whole string literal and puts `line N, column C within the text` in the message text instead.
+  Worth revisiting if/when `subspan` stabilises.
+- **A single-expression form** (`omn_class!`/`omn_axiom!` for one class expression or axiom
+  rather than a whole document) — `io::omn::reader::parse_class_expression` already exists and
+  is the right building block if this is wanted later; not v1.
+- **Should semantic (not just syntax) errors also be caught at compile time?** Would need the
+  proc-macro to either duplicate the declaration pre-pass or find a way to run the *real* semantic
+  reader at compile time without a live `Build<A>` (e.g. a compile-time-only dummy `ForIRI`
+  impl just for validation, discarding the interned IRIs afterward). Deferred pending evidence
+  this is a real gap, not a hypothetical one — see the "Design decision" trade-off note above.

--- a/horned-macro/Cargo.toml
+++ b/horned-macro/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "horned-macro"
+version = "0.1.0"
+authors = ["Phillip Lord"]
+description = "Write Manchester Syntax (and, later, OWL Functional Syntax) directly in Rust source, checked at compile time"
+repository = "https://github.com/phillord/horned-owl"
+edition = "2024"
+license = "LGPL-3.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+horned-owl = { path = "..", version = "2.1.0" }
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
+
+[dev-dependencies]
+trybuild = "1"

--- a/horned-macro/src/lib.rs
+++ b/horned-macro/src/lib.rs
@@ -1,0 +1,151 @@
+//! Write Manchester Syntax ([`omn!`]) or OWL Functional Syntax ([`ofn!`])
+//! directly in Rust source -- named after the file extension each
+//! format already uses elsewhere in this repo (`.omn`, `.ofn`).
+//!
+//! See `docs/horned-macro-plan.md` at the repository root for the design
+//! rationale. In short: each macro checks the embedded text against the
+//! real grammar at compile time (a genuine Rust compile error on a
+//! syntax mistake), then expands to a call into the corresponding
+//! `horned_owl::io::{omn,ofn}::reader::read_with_build` -- the same,
+//! already-tested runtime reader -- rather than re-implementing any of
+//! its semantics inside the macro.
+//!
+//! The document is a quoted string, not bare tokens. An earlier version
+//! of `omn!` took unquoted tokens instead (no string at all) -- see
+//! `docs/horned-macro-plan.md`'s "Unquoted tokens: tried and reverted"
+//! section for why that was abandoned: it could never accept a full
+//! `<http://...>` IRI (Rust's lexer strips `//` as a comment before any
+//! macro sees tokens), which meant it wasn't actually accepting the
+//! real grammar, only a CURIE-only dialect of it. A quoted string has
+//! no such restriction -- the full grammar `read_with_build` already
+//! supports is available here, unrestricted.
+
+use horned_owl::io::ofn::reader::{OwlFunctionalLexer, Rule as OfnRule};
+use horned_owl::io::omn::reader::{ManchesterLexer, Rule as OmnRule};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Expr, LitStr, Token, parse_macro_input};
+
+struct MacroInput {
+    build: Expr,
+    text: LitStr,
+}
+
+impl Parse for MacroInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let build: Expr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let text: LitStr = input.parse()?;
+        Ok(MacroInput { build, text })
+    }
+}
+
+/// Shared expansion for `omn!`/`ofn!`: run the grammar's own
+/// pure-syntax check against the text, and on success emit a call into
+/// the real runtime reader.
+fn expand(
+    input: TokenStream,
+    label: &str,
+    check: impl Fn(&str) -> Result<(), String>,
+    reader_call: proc_macro2::TokenStream,
+) -> TokenStream {
+    let MacroInput { build, text } = parse_macro_input!(input as MacroInput);
+    let source_text = text.value();
+
+    if let Err(e) = check(source_text.trim()) {
+        let message = format!("{label}!: invalid syntax: {e}");
+        return syn::Error::new(text.span(), message)
+            .to_compile_error()
+            .into();
+    }
+
+    let expanded = quote! {
+        match #reader_call(#text.as_bytes(), #build) {
+            ::std::result::Result::Ok((onto, _prefixes)) => onto,
+            ::std::result::Result::Err(e) => panic!(
+                "horned-macro: `{}!` passed its compile-time syntax check but failed at \
+                 runtime construction ({{e}}); this means the text is syntactically valid \
+                 but was semantically rejected -- see docs/horned-macro-plan.md in the \
+                 horned-owl repository",
+                #label,
+            ),
+        }
+    };
+
+    expanded.into()
+}
+
+/// Parse `$text` as a Manchester Syntax document at compile time, and
+/// expand to code that constructs the ontology at runtime via `$build`
+/// (a `&Build<A>` for whatever `A: ForIRI` the surrounding code uses).
+///
+/// ```
+/// # use horned_owl::model::Build;
+/// # use horned_owl::ontology::set::SetOntology;
+/// # use horned_macro::omn;
+/// let b = Build::new_rc();
+/// let onto: SetOntology<_> = omn!(&b, "
+///     Prefix: : <http://example.org/>
+///     Class: Foo
+///     Class: Bar
+///         SubClassOf: Foo
+/// ");
+/// ```
+///
+/// A syntax mistake in the embedded text is a compile error at the
+/// macro invocation site. See `docs/horned-macro-plan.md` for why
+/// *semantic* errors (rare -- e.g. a `HasKey:` data/object key
+/// ambiguity) are not caught until runtime, where they surface as a
+/// panic from this macro's expansion rather than a compile error.
+#[proc_macro]
+pub fn omn(input: TokenStream) -> TokenStream {
+    expand(
+        input,
+        "omn",
+        |text| {
+            ManchesterLexer::lex(OmnRule::ManchesterDocument, text)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        },
+        quote! { ::horned_owl::io::omn::reader::read_with_build },
+    )
+}
+
+/// Parse `$text` as an OWL Functional Syntax document at compile time,
+/// and expand to code that constructs the ontology at runtime via
+/// `$build` (a `&Build<A>` for whatever `A: ForIRI` the surrounding
+/// code uses).
+///
+/// ```
+/// # use horned_owl::model::Build;
+/// # use horned_owl::ontology::set::SetOntology;
+/// # use horned_macro::ofn;
+/// let b = Build::new_rc();
+/// let onto: SetOntology<_> = ofn!(&b, "
+///     Prefix(:=<http://example.org/>)
+///     Ontology(<http://example.org/>
+///         Declaration(Class(:Foo))
+///         Declaration(Class(:Bar))
+///         SubClassOf(:Bar :Foo)
+///     )
+/// ");
+/// ```
+///
+/// A syntax mistake in the embedded text is a compile error at the
+/// macro invocation site. See `docs/horned-macro-plan.md` for why
+/// *semantic* errors are not caught until runtime, where they surface
+/// as a panic from this macro's expansion rather than a compile error.
+#[proc_macro]
+pub fn ofn(input: TokenStream) -> TokenStream {
+    expand(
+        input,
+        "ofn",
+        |text| {
+            OwlFunctionalLexer::lex(OfnRule::OntologyDocument, text)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        },
+        quote! { ::horned_owl::io::ofn::reader::read_with_build },
+    )
+}

--- a/horned-macro/tests/ofn.rs
+++ b/horned-macro/tests/ofn.rs
@@ -1,0 +1,39 @@
+use horned_macro::ofn;
+use horned_owl::model::{Build, ClassExpression, Component, RcStr, SubClassOf};
+use horned_owl::ontology::set::SetOntology;
+
+#[test]
+fn constructs_a_small_ontology() {
+    let b: Build<RcStr> = Build::new_rc();
+    let onto: SetOntology<RcStr> = ofn!(
+        &b,
+        "
+        Prefix(:=<http://example.org/>)
+        Ontology(<http://example.org/>
+            Declaration(Class(:Foo))
+            Declaration(Class(:Bar))
+            SubClassOf(:Bar :Foo)
+        )
+        "
+    );
+
+    let foo = b.class("http://example.org/Foo");
+    let bar = b.class("http://example.org/Bar");
+
+    let expected_subclass = Component::SubClassOf(SubClassOf {
+        sup: ClassExpression::Class(foo),
+        sub: ClassExpression::Class(bar),
+    });
+
+    let found = onto.iter().any(|ac| ac.component == expected_subclass);
+    assert!(
+        found,
+        "expected SubClassOf(Bar, Foo) in the parsed ontology"
+    );
+}
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/ofn_*.rs");
+}

--- a/horned-macro/tests/omn.rs
+++ b/horned-macro/tests/omn.rs
@@ -1,0 +1,62 @@
+use horned_macro::omn;
+use horned_owl::model::{Build, ClassExpression, Component, RcStr, SubClassOf};
+use horned_owl::ontology::set::SetOntology;
+
+#[test]
+fn constructs_a_small_ontology() {
+    let b: Build<RcStr> = Build::new_rc();
+    let onto: SetOntology<RcStr> = omn!(
+        &b,
+        "
+        Prefix: : <http://example.org/>
+        Class: Foo
+        Class: Bar
+            SubClassOf: Foo
+        "
+    );
+
+    let foo = b.class("http://example.org/Foo");
+    let bar = b.class("http://example.org/Bar");
+
+    let expected_subclass = Component::SubClassOf(SubClassOf {
+        sup: ClassExpression::Class(foo),
+        sub: ClassExpression::Class(bar),
+    });
+
+    let found = onto.iter().any(|ac| ac.component == expected_subclass);
+    assert!(
+        found,
+        "expected SubClassOf(Bar, Foo) in the parsed ontology"
+    );
+}
+
+#[test]
+fn works_with_a_bare_iri_and_no_prefix_declaration() {
+    let b: Build<RcStr> = Build::new_rc();
+    let onto: SetOntology<RcStr> = omn!(&b, "Class: <http://example.org/OnlyClass>");
+    assert_eq!(onto.iter().count(), 1);
+}
+
+#[test]
+fn ui() {
+    // trybuild compiles tests/ui/*.rs and checks the output against the
+    // matching *.stderr -- this is the "a syntax mistake is a genuine
+    // compile error" guarantee that's the whole point of the macro.
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/bad_syntax.rs");
+}
+
+#[test]
+fn works_with_a_raw_string() {
+    let b: Build<RcStr> = Build::new_rc();
+    let onto: SetOntology<RcStr> = omn!(
+        &b,
+        r#"
+        Prefix: : <http://example.org/>
+        Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        Class: Foo
+            Annotations: rdfs:comment "contains a \backslash and \"escaped-looking\" text, untouched by a raw string"
+        "#
+    );
+    assert_eq!(onto.iter().count(), 2); // the Class: declaration plus its annotation assertion
+}

--- a/horned-macro/tests/ui/bad_syntax.rs
+++ b/horned-macro/tests/ui/bad_syntax.rs
@@ -1,0 +1,8 @@
+use horned_macro::omn;
+use horned_owl::model::{Build, RcStr};
+use horned_owl::ontology::set::SetOntology;
+
+fn main() {
+    let b: Build<RcStr> = Build::new_rc();
+    let _onto: SetOntology<RcStr> = omn!(&b, "Class: Foo SubClassOf");
+}

--- a/horned-macro/tests/ui/bad_syntax.stderr
+++ b/horned-macro/tests/ui/bad_syntax.stderr
@@ -1,0 +1,10 @@
+error: omn!: invalid syntax: Parsing Error:  --> 1:12
+         |
+       1 | Class: Foo SubClassOf
+         |            ^---
+         |
+         = expected EOI, OrKw, AndKw, SomeKw, OnlyKw, ValueKw, SelfKw, MinKw, MaxKw, ExactlyKw, GeneralAxiomBlock, Annotations, Frame, or Misc
+ --> tests/ui/bad_syntax.rs:7:46
+  |
+7 |     let _onto: SetOntology<RcStr> = omn!(&b, "Class: Foo SubClassOf");
+  |                                              ^^^^^^^^^^^^^^^^^^^^^^^

--- a/horned-macro/tests/ui/ofn_bad_syntax.rs
+++ b/horned-macro/tests/ui/ofn_bad_syntax.rs
@@ -1,0 +1,8 @@
+use horned_macro::ofn;
+use horned_owl::model::{Build, RcStr};
+use horned_owl::ontology::set::SetOntology;
+
+fn main() {
+    let b: Build<RcStr> = Build::new_rc();
+    let _onto: SetOntology<RcStr> = ofn!(&b, "Ontology(<http://example.org/> Declaration(");
+}

--- a/horned-macro/tests/ui/ofn_bad_syntax.stderr
+++ b/horned-macro/tests/ui/ofn_bad_syntax.stderr
@@ -1,0 +1,10 @@
+error: ofn!: invalid syntax: Parsing Error:  --> 1:44
+         |
+       1 | Ontology(<http://example.org/> Declaration(
+         |                                            ^---
+         |
+         = expected Entity or Annotation
+ --> tests/ui/ofn_bad_syntax.rs:7:46
+  |
+7 |     let _onto: SetOntology<RcStr> = ofn!(&b, "Ontology(<http://example.org/> Declaration(");
+  |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/io/ofn/reader/mod.rs
+++ b/src/io/ofn/reader/mod.rs
@@ -10,12 +10,11 @@ use crate::model::MutableOntology;
 use crate::model::Ontology;
 
 mod from_pair;
-mod lexer;
+pub mod lexer;
 
 use self::from_pair::FromPair;
 use self::from_pair::MutableOntologyWrapper;
-use self::lexer::OwlFunctionalLexer;
-use self::lexer::Rule;
+pub use self::lexer::{OwlFunctionalLexer, Rule};
 
 struct Context<'a, A: ForIRI> {
     build: &'a Build<A>,

--- a/tests/horned_macro_smoke.rs
+++ b/tests/horned_macro_smoke.rs
@@ -1,0 +1,25 @@
+//! A small dogfooding smoke test for the `horned-macro` crate's `omn!`
+//! macro, added as a dev-dependency (see docs/horned-macro-plan.md,
+//! phase 6). Not a rewrite of existing fixtures -- just proof the
+//! macro works from within `horned-owl`'s own test suite, the way a
+//! downstream test fixture would use it.
+
+use horned_macro::omn;
+use horned_owl::model::{Build, RcStr};
+use horned_owl::ontology::set::SetOntology;
+
+#[test]
+fn omn_macro_builds_an_ontology() {
+    let b: Build<RcStr> = Build::new_rc();
+    let onto: SetOntology<RcStr> = omn!(
+        &b,
+        "
+        Prefix: : <http://example.org/>
+        Class: Pizza
+        Class: Margherita
+            SubClassOf: Pizza
+        "
+    );
+
+    assert_eq!(onto.iter().count(), 3); // 2 declarations + 1 SubClassOf
+}


### PR DESCRIPTION
## Summary

New proc-macro crate providing `omn!(&build, "...")` and `ofn!(&build, "...")` macros, named after the file extension each syntax already uses elsewhere in this repo. Each checks the embedded document against the real grammar at compile time (a genuine `rustc` error on a syntax mistake, proven with a `trybuild` negative test per macro), then expands to a call into the existing, already-tested `read_with_build` reader for that format at runtime — no parsing semantics duplicated inside the macro itself.

- `ofn!` needed one small `horned-owl` change: `src/io/ofn/reader/mod.rs`'s lexer/`Rule` weren't exported the way the Manchester reader's already were.
- Wired into `horned-owl` as a dev-dependency (a dev-dependency cycle, supported by Cargo) with an illustrative smoke test.
- Full design history — including an unquoted-tokens calling convention that was built, tested, and then reverted because it could never represent a full `<http://...>` IRI — is in `docs/horned-macro-plan.md`.

Rebased onto `devel` post-#224 (`horned-catalog`) merge; both new workspace members now coexist.

## Test plan

- [x] Full workspace `cargo test` green (1357+ tests) after rebase
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `trybuild` negative-compile tests prove a genuine syntax mistake in either macro is a compile error, not a runtime panic