### PR TITLE
Fix 12 horned-roundtrip corpus reread_fail regressions

### DIFF
--- a/src/grammars/bcp47.pest
+++ b/src/grammars/bcp47.pest
@@ -17,8 +17,18 @@ BCP47_Language = ${
 // script subtag (e.g. `zh-Hans` -> `zh` + extlang `Han`, stranding `s`); the
 // guards force extlang to yield so the script subtag can match.
 BCP47_ExtLang       = ${ ASCII_ALPHA{3} ~ !ASCII_ALPHA ~ ("-" ~ ASCII_ALPHA{3} ~ !ASCII_ALPHA){,2} }
-BCP47_Script        = ${ ASCII_ALPHA{4} }
-BCP47_Region        = ${ ASCII_ALPHA{2} | ASCII_DIGIT{3} }
+// Script and region are fixed-length subtags (4 alpha / 2 alpha or 3
+// digit), but that length is only a *minimum* match for a PEG engine --
+// without a trailing `!ASCII_ALPHANUMERIC` guard, a longer, unhyphenated
+// variant subtag right after the language (e.g. the 8-alphanumeric variant
+// in `en-scotland`) gets wrongly truncated: `scot` matches `BCP47_Script`
+// and the remaining `land` is left stranded with no `-` before it, so the
+// whole tag fails to parse
+// (https://github.com/phillord/horned-owl/issues/236). The guards force
+// script/region to yield to the longer variant match, mirroring the
+// extlang guards above.
+BCP47_Script        = ${ ASCII_ALPHA{4} ~ !ASCII_ALPHANUMERIC }
+BCP47_Region        = ${ (ASCII_ALPHA{2} | ASCII_DIGIT{3}) ~ !ASCII_ALPHANUMERIC }
 BCP47_Variant       = ${ ASCII_ALPHANUMERIC{5, 8} | ASCII_DIGIT ~ ASCII_ALPHANUMERIC{3} }
 BCP47_Extension     = ${ BCP47_Singleton ~ ("-" ~ ASCII_ALPHANUMERIC{2, 8})+ }
 BCP47_Singleton     = @{ ASCII_DIGIT | '\u{41}'..'\u{57}' | '\u{59}'..'\u{5A}' | '\u{61}'..'\u{77}' | '\u{79}'..'\u{7A}' }

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -10,6 +10,64 @@ use enum_meta::Meta;
 use crate::model::*;
 use crate::vocab::Facet;
 
+/// Check whether `c` is a `SPARQL_PnCharsBase` character, as defined by
+/// `src/grammars/sparql.pest` (mirrors the SPARQL 1.0 `PN_CHARS_BASE`
+/// production that OFN's `AbbreviatedIRI` local names are built on).
+fn is_pn_chars_base(c: char) -> bool {
+    c.is_ascii_alphabetic()
+        || ('\u{00C0}'..='\u{00D6}').contains(&c)
+        || ('\u{00D8}'..='\u{00F6}').contains(&c)
+        || ('\u{00F8}'..='\u{02FF}').contains(&c)
+        || ('\u{0370}'..='\u{037D}').contains(&c)
+        || ('\u{037F}'..='\u{1FFF}').contains(&c)
+        || ('\u{200C}'..='\u{200D}').contains(&c)
+        || ('\u{2070}'..='\u{218F}').contains(&c)
+        || ('\u{2C00}'..='\u{2FEF}').contains(&c)
+        || ('\u{3001}'..='\u{D7FF}').contains(&c)
+        || ('\u{F900}'..='\u{FDCF}').contains(&c)
+        || ('\u{FDF0}'..='\u{FFFD}').contains(&c)
+        || ('\u{10000}'..='\u{EFFFF}').contains(&c)
+}
+
+/// `SPARQL_PnCharsU`: `SPARQL_PnCharsBase` plus `_`.
+fn is_pn_chars_u(c: char) -> bool {
+    is_pn_chars_base(c) || c == '_'
+}
+
+/// `SPARQL_PnChars`: `SPARQL_PnCharsU` plus `-`, ASCII digits, and a handful
+/// of extra code points the grammar allows mid-name.
+fn is_pn_chars(c: char) -> bool {
+    is_pn_chars_u(c)
+        || c == '-'
+        || c.is_ascii_digit()
+        || c == '\u{00B7}'
+        || ('\u{0300}'..='\u{036F}').contains(&c)
+        || ('\u{203F}'..='\u{2040}').contains(&c)
+}
+
+/// Check whether `s` is usable as an OFN `AbbreviatedIRI` local name (the
+/// `SPARQL_PnLocal` production: a leading `PnCharsU`/digit followed by any
+/// number of `PnChars` or `.`, and not ending in `.`).
+///
+/// This is conservative rather than a byte-for-byte match of the grammar
+/// (e.g. it allows consecutive `.` characters mid-name, which the grammar's
+/// `("." ~ PnChars)*` repetition technically doesn't); false negatives here
+/// just mean an abbreviation opportunity is missed in favour of the always-
+/// correct `<full IRI>` form, whereas a false positive would write out an
+/// unparseable `AbbreviatedIRI`, so erring conservative in that direction
+/// would be the wrong trade-off.
+fn is_valid_pn_local(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_pn_chars_u(c) || c.is_ascii_digit() => {}
+        _ => return false,
+    }
+    if s.ends_with('.') {
+        return false;
+    }
+    chars.all(|c| is_pn_chars(c) || c == '.')
+}
+
 /// Write a string literal while escaping `"` and `\` characters.
 fn quote(mut s: &str, f: &mut Formatter<'_>) -> Result<(), Error> {
     f.write_str("\"")?;
@@ -900,7 +958,28 @@ impl<A: ForIRI> Display for Functional<'_, IRI<A>, A> {
         if let Some(prefixes) = self.1.as_ref() {
             match prefixes.shrink_iri(self.0) {
                 Err(_) => write!(f, "<{}>", self.0),
-                Ok(curie) => write!(f, "{curie}"),
+                Ok(curie) => {
+                    // `curie::Curie` doesn't expose its `prefix`/`reference`
+                    // parts other than through `Display`, so recover the
+                    // local-name part from the rendered string: this
+                    // grammar's `PN_CHARS` doesn't include `:`, so the first
+                    // `:` (if any) reliably separates prefix from local name
+                    // (a colon-less rendering, e.g. the `curie` crate's
+                    // "default prefix" fast path, means the whole string is
+                    // the local name). Only trust the abbreviation if that
+                    // local name is actually a legal OFN `PN_LOCAL` --
+                    // otherwise fall back to the always-valid `<full IRI>`
+                    // form, same as the `Err(_)` branch above.
+                    let rendered = curie.to_string();
+                    let local = rendered
+                        .split_once(':')
+                        .map_or(rendered.as_str(), |(_, local)| local);
+                    if is_valid_pn_local(local) {
+                        f.write_str(&rendered)
+                    } else {
+                        write!(f, "<{}>", self.0)
+                    }
+                }
             }
         } else {
             write!(f, "<{}>", self.0)
@@ -1199,6 +1278,33 @@ mod tests {
             "Declaration(Class(<http://xmlns.com/foaf/0.1/Person>))",
             ofn
         );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/231
+    //
+    // A local name that matches a registered prefix but contains a
+    // character illegal in OFN's PN_LOCAL (here a literal `/`) must not be
+    // abbreviated -- the abbreviated form would not be valid OFN and would
+    // fail to reread. It must fall back to the `<full IRI>` form instead,
+    // exactly as if no prefix had matched at all.
+    #[test]
+    fn test_ofn_curie_invalid_pn_local_falls_back_to_full_iri() {
+        let build = Build::new_arc();
+        let mut prefixes = curie::PrefixMapping::default();
+        prefixes.add_prefix("", "http://example.org/mini#").ok();
+
+        let decl = DeclareClass(build.class("http://example.org/mini#Direct/Indirect"));
+        let ofn = format!("{}", decl.as_functional_with_prefixes(&prefixes));
+        assert_eq!(
+            "Declaration(Class(<http://example.org/mini#Direct/Indirect>))",
+            ofn
+        );
+
+        // A local name with only legal PN_LOCAL characters is unaffected
+        // and is still abbreviated as before.
+        let decl = DeclareClass(build.class("http://example.org/mini#Direct"));
+        let ofn = format!("{}", decl.as_functional_with_prefixes(&prefixes));
+        assert_eq!("Declaration(Class(:Direct))", ofn);
     }
 
     #[test]

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -671,12 +671,31 @@ impl<A: ForIRI> Display for Functional<'_, ClassExpression<A>, A> {
         }
         match self.0 {
             Class(exp) => Functional(exp, self.1, None).fmt(f),
+            // `ObjectIntersectionOf`/`ObjectUnionOf` require at least two
+            // operands in the OWL 2 Functional-Style Syntax grammar
+            // (`ClassExpression{2, }` in `src/grammars/ofn.pest`, matching
+            // the OWL 2 spec: https://www.w3.org/TR/owl2-syntax/#Class_Expressions).
+            // `ClassExpression` itself is an unconstrained `Vec`, and
+            // horned-owl's RDF reader is lenient about (real-world, if
+            // technically malformed) `owl:intersectionOf`/`owl:unionOf` RDF
+            // lists with only one member, building a single-operand variant
+            // (see https://github.com/phillord/horned-owl/issues/235).
+            // Writing that out verbatim as `ObjectIntersectionOf(x)`
+            // produces OFN our own reader then rejects. An
+            // intersection/union of a single set is that set, so degrade to
+            // writing the sole operand directly instead.
+            ObjectIntersectionOf(classes) if classes.len() == 1 => {
+                Functional(&classes[0], self.1, None).fmt(f)
+            }
             ObjectIntersectionOf(classes) => {
                 write!(
                     f,
                     "ObjectIntersectionOf({})",
                     Functional(classes, self.1, None)
                 )
+            }
+            ObjectUnionOf(classes) if classes.len() == 1 => {
+                Functional(&classes[0], self.1, None).fmt(f)
             }
             ObjectUnionOf(classes) => {
                 write!(f, "ObjectUnionOf({})", Functional(classes, self.1, None))

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -895,12 +895,65 @@ impl<A: ForIRI> AsFunctional<A> for IArgument<A> {}
 
 // ---------------------------------------------------------------------------
 
+/// Whether `s` is usable, as-is, as an OFN `AbbreviatedIRI` local part
+/// (`SPARQL_PnLocal` in `src/grammars/sparql.pest`: a `PN_CHARS_U`/digit,
+/// followed by any run of `PN_CHARS`/`.`/`-`/`_`). This is a conservative
+/// approximation of the real grammar -- it rejects some strings the full
+/// grammar would accept (e.g. it doesn't special-case interior dots the way
+/// the grammar's `("." ~ PN_CHARS)*` alternation does) -- but that only
+/// costs an occasional missed abbreviation, never invalid output: callers
+/// fall back to the always-valid full `<IRI>` form when this returns
+/// `false`.
+fn is_valid_ofn_local_part(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_alphanumeric() || c == '_' => {}
+        _ => return false,
+    }
+    s.chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
+/// Abbreviate `iri` against `prefixes` as `prefix:local`, if possible.
+///
+/// This does not delegate to `curie::PrefixMapping::shrink_iri` because that
+/// method special-cases a match against the mapping's "default" IRI (set via
+/// `PrefixMapping::set_default`, as the OWL/XML reader does for an
+/// empty-name `<Prefix name="" IRI="..."/>`) by returning a `Curie` with
+/// `prefix: None` -- and `curie::Curie`'s `Display` renders that as the bare
+/// local part with **no colon at all**, which is not a valid OFN
+/// `AbbreviatedIRI` (`SPARQL_PnameLn` always requires the colon, even for an
+/// empty prefix name, i.e. `:local`). It can also hand back a local part
+/// that starts with `#` (when the matched prefix IRI has no trailing `/`/`#`
+/// but the full IRI does), which is never valid in this position either way.
+/// See https://github.com/phillord/horned-owl/issues/230.
+///
+/// Instead this walks `prefixes.mappings()` directly (the same
+/// insertion-ordered, first-match-wins semantics `shrink_iri` itself uses
+/// for its non-default branch) and only accepts a match whose local part
+/// passes [`is_valid_ofn_local_part`], always emitting the colon -- so an
+/// empty-name prefix match correctly becomes `:local`, not `local`. A
+/// mapping that was only ever `set_default`-ed, with no corresponding
+/// `add_prefix("", ...)`, is not visible via `mappings()` and so is never
+/// abbreviated by this function; such IRIs are written out in full instead,
+/// which is always valid, if slightly more verbose.
+fn shrink_iri_for_ofn<'a>(prefixes: &'a PrefixMapping, iri: &str) -> Option<(&'a str, String)> {
+    for (name, value) in prefixes.mappings() {
+        if let Some(local) = iri.strip_prefix(value.as_str())
+            && is_valid_ofn_local_part(local)
+        {
+            return Some((name.as_str(), local.to_string()));
+        }
+    }
+    None
+}
+
 impl<A: ForIRI> Display for Functional<'_, IRI<A>, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         if let Some(prefixes) = self.1.as_ref() {
-            match prefixes.shrink_iri(self.0) {
-                Err(_) => write!(f, "<{}>", self.0),
-                Ok(curie) => write!(f, "{curie}"),
+            match shrink_iri_for_ofn(prefixes, self.0) {
+                Some((name, local)) => write!(f, "{name}:{local}"),
+                None => write!(f, "<{}>", self.0),
             }
         } else {
             write!(f, "<{}>", self.0)
@@ -1197,6 +1250,47 @@ mod tests {
         let ofn = format!("{}", decl.as_functional_with_prefixes(&prefixes));
         assert_eq!(
             "Declaration(Class(<http://xmlns.com/foaf/0.1/Person>))",
+            ofn
+        );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/230
+    // An empty/default CURIE prefix (as the OWL/XML reader creates via
+    // `add_prefix("", iri)` + `set_default(iri)` for a `<Prefix name=""
+    // IRI="..."/>` element) must still abbreviate with the leading colon
+    // `:local` -- not the bare `local` that `curie::Curie`'s own `Display`
+    // produces for a `prefix: None` match, which isn't a valid OFN
+    // `AbbreviatedIRI` at all.
+    #[test]
+    fn test_ofn_curie_empty_prefix() {
+        let build = Build::new_arc();
+        let mut prefixes = curie::PrefixMapping::default();
+        prefixes.add_prefix("", "http://identifiers.org/mamo#").ok();
+        prefixes.set_default("http://identifiers.org/mamo#");
+
+        let decl = DeclareClass(build.class("http://identifiers.org/mamo#MAMO_0000207"));
+        let ofn = format!("{}", decl.as_functional_with_prefixes(&prefixes));
+        assert_eq!("Declaration(Class(:MAMO_0000207))", ofn);
+    }
+
+    // Same bug, but for the shape seen in the `MAMO` corpus ontology itself:
+    // the default-prefix IRI has no trailing `/` or `#` separator, so the
+    // leftover local part starts with `#` (from the entity IRI's own
+    // fragment separator). `#` is not a legal `PN_LOCAL` character in OFN's
+    // grammar, so this must fall back to the full `<IRI>` form rather than
+    // emit `:#MAMO_0000207` (still invalid) or the pre-fix `#MAMO_0000207`
+    // (invalid for a second, independent reason -- no colon at all).
+    #[test]
+    fn test_ofn_curie_empty_prefix_no_separator_falls_back_to_full_iri() {
+        let build = Build::new_arc();
+        let mut prefixes = curie::PrefixMapping::default();
+        prefixes.add_prefix("", "http://identifiers.org/mamo").ok();
+        prefixes.set_default("http://identifiers.org/mamo");
+
+        let decl = DeclareClass(build.class("http://identifiers.org/mamo#MAMO_0000207"));
+        let ofn = format!("{}", decl.as_functional_with_prefixes(&prefixes));
+        assert_eq!(
+            "Declaration(Class(<http://identifiers.org/mamo#MAMO_0000207>))",
             ofn
         );
     }

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -10,6 +10,63 @@ use enum_meta::Meta;
 use crate::model::*;
 use crate::vocab::Facet;
 
+/// Check whether `c` must be percent-encoded before it can appear inside an
+/// OFN `<...>` full IRI.
+///
+/// horned-owl's IRI type is just an interned string -- it does not validate
+/// that the text is a legal RFC 3987 IRI on construction (readers for XML-
+/// and RDF-based formats hand IRI attribute/node text straight through, and
+/// those formats don't require it to already be percent-encoded). Real-world
+/// ontologies exploit this laxity: e.g. a fragment of `KB-CH[R]-8-5`, with a
+/// literal `[`/`]` pair, is valid as an XML attribute value but is not a
+/// legal `RFC3987_IriFragment` per `src/grammars/rfc3987.pest` (`[`/`]` are
+/// gen-delims, only legal inside the authority's `IP-literal` production).
+/// Writing such text raw into `<...>` therefore produces OFN the writer's
+/// own reader then rejects.
+///
+/// This list is deliberately conservative rather than a full RFC 3987
+/// legality check (which is position-dependent -- e.g. `:` and `/` are fine
+/// in most positions but not all): it covers the ASCII "gen-delims and
+/// unwise" characters that are never legal in an IRI's path/query/fragment
+/// (`[`, `]`, `<`, `>`, `"`, space, backslash, backtick, `^`, `{`, `|`, `}`)
+/// plus control characters, all of which are unconditionally illegal
+/// anywhere in an IRI. It does not attempt to flag characters that are only
+/// sometimes illegal (like a stray `#` or `?`), so a small number of
+/// pathological IRIs could still round-trip incorrectly -- but false
+/// negatives here just leave already-broken input broken, whereas encoding
+/// too aggressively would mangle otherwise-valid IRIs, so erring toward the
+/// conservative list is the safer trade-off (mirrors the same reasoning in
+/// `is_valid_pn_local` below).
+fn needs_iri_percent_encoding(c: char) -> bool {
+    matches!(
+        c,
+        '[' | ']' | '<' | '>' | '"' | ' ' | '\\' | '`' | '^' | '{' | '|' | '}'
+    ) || c.is_control()
+}
+
+/// Percent-encode any character in `s` that [`needs_iri_percent_encoding`]
+/// flags, leaving everything else (including any `%XX` sequences already
+/// present) untouched. Returns a borrowed `Cow` when nothing needed
+/// encoding, so the common case (already-legal IRIs) allocates nothing.
+fn percent_encode_iri(s: &str) -> std::borrow::Cow<'_, str> {
+    if !s.chars().any(needs_iri_percent_encoding) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut buf = [0u8; 4];
+    for c in s.chars() {
+        if needs_iri_percent_encoding(c) {
+            for b in c.encode_utf8(&mut buf).as_bytes() {
+                out.push('%');
+                out.push_str(&format!("{b:02X}"));
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
 /// Write a string literal while escaping `"` and `\` characters.
 fn quote(mut s: &str, f: &mut Formatter<'_>) -> Result<(), Error> {
     f.write_str("\"")?;
@@ -899,11 +956,11 @@ impl<A: ForIRI> Display for Functional<'_, IRI<A>, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         if let Some(prefixes) = self.1.as_ref() {
             match prefixes.shrink_iri(self.0) {
-                Err(_) => write!(f, "<{}>", self.0),
+                Err(_) => write!(f, "<{}>", percent_encode_iri(self.0)),
                 Ok(curie) => write!(f, "{curie}"),
             }
         } else {
-            write!(f, "<{}>", self.0)
+            write!(f, "<{}>", percent_encode_iri(self.0))
         }
     }
 }
@@ -1042,7 +1099,7 @@ impl<A: ForIRI> AsFunctional<A> for Variable<A> {}
 impl<A: ForIRI> Display for Functional<'_, curie::PrefixMapping, A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         for (name, value) in self.0.mappings() {
-            writeln!(f, "Prefix({name}:=<{value}>)")?;
+            writeln!(f, "Prefix({name}:=<{}>)", percent_encode_iri(value))?;
         }
         Ok(())
     }
@@ -1198,6 +1255,55 @@ mod tests {
         assert_eq!(
             "Declaration(Class(<http://xmlns.com/foaf/0.1/Person>))",
             ofn
+        );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/234
+    //
+    // A literal '[' or ']' in an IRI is legal in an XML attribute (so real-
+    // world OWL/XML ontologies contain it -- e.g. a fragment like
+    // "KB-CH[R]-8-5") but is not legal, unescaped, inside OFN's `<...>`
+    // FullIRI production (per src/grammars/rfc3987.pest, '[' and ']' are
+    // gen-delims only permitted inside the authority's IP-literal). Writing
+    // such an IRI raw produces OFN that horned-owl's own reader then
+    // rejects on reread. Both the full-IRI form (no prefix match) and the
+    // `Prefix(name:=<...>)` declaration line must percent-encode it.
+    #[test]
+    fn test_ofn_iri_with_illegal_characters_is_percent_encoded() {
+        let build = Build::new_arc();
+
+        // No prefixes in scope: full <...> form must be percent-encoded.
+        let decl = DeclareClass(build.class("http://example.org/KB-CH[R]-8-5"));
+        let ofn = format!("{}", decl.as_functional());
+        assert_eq!(
+            "Declaration(Class(<http://example.org/KB-CH%5BR%5D-8-5>))",
+            ofn
+        );
+
+        // The round-tripped text must be re-parseable as OFN.
+        let reparsed: Result<(crate::ontology::set::SetOntology<RcStr>, _), _> =
+            crate::io::ofn::reader::read(
+                std::io::Cursor::new(format!(
+                    "Prefix(:=<http://ex/>)\nOntology(<http://ex/o>\n{ofn}\n)"
+                )),
+                Default::default(),
+            );
+        assert!(reparsed.is_ok(), "reparse failed: {reparsed:?}");
+
+        // A `Prefix(name:=<...>)` declaration line (rendered directly from
+        // a PrefixMapping, as happens for the recovered mapping from an
+        // OWL/XML source) must also percent-encode illegal characters.
+        let mut prefixes = curie::PrefixMapping::default();
+        prefixes
+            .add_prefix("R", "http://example.org/KB-CH[R]-8-5")
+            .ok();
+        let rendered = format!(
+            "{}",
+            Functional::<curie::PrefixMapping, RcStr>(&prefixes, None, None)
+        );
+        assert_eq!(
+            "Prefix(R:=<http://example.org/KB-CH%5BR%5D-8-5>)\n",
+            rendered
         );
     }
 

--- a/src/io/ofn/writer/mod.rs
+++ b/src/io/ofn/writer/mod.rs
@@ -145,6 +145,64 @@ mod test {
         );
     }
 
+    // Regression test for https://github.com/phillord/horned-owl/issues/235
+    // `ObjectIntersectionOf`/`ObjectUnionOf` require at least two operands in
+    // the OFN grammar (`ClassExpression{2, }` in `src/grammars/ofn.pest`),
+    // but `ClassExpression::ObjectIntersectionOf`/`ObjectUnionOf` are plain
+    // `Vec`s with no arity check, and horned-owl's RDF reader is lenient
+    // about real-world (if technically malformed) single-member
+    // `owl:intersectionOf`/`owl:unionOf` RDF lists -- see the `BCS7` corpus
+    // ontology's `owl:intersectionOf ( cst:M1 )`. Such a degenerate
+    // single-operand `ObjectIntersectionOf`/`ObjectUnionOf` can't be built
+    // by parsing OFN (the reader enforces the grammar's minimum), so it's
+    // constructed directly via the model API here, matching how the RDF
+    // reader would produce it.
+    #[test]
+    fn roundtrip_degenerate_single_operand_intersection_and_union() {
+        use crate::model::Build;
+        use crate::model::ClassExpression;
+        use crate::model::MutableOntology;
+        use crate::model::SubClassOf;
+
+        let build = Build::<RcStr>::new();
+        let mut ont: ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>> =
+            ComponentMappedOntology::new();
+        ont.insert(SubClassOf {
+            sub: ClassExpression::Class(build.class("http://example.com/Sub")),
+            sup: ClassExpression::ObjectIntersectionOf(vec![ClassExpression::Class(
+                build.class("http://example.com/One"),
+            )]),
+        });
+        ont.insert(SubClassOf {
+            sub: ClassExpression::Class(build.class("http://example.com/Sub2")),
+            sup: ClassExpression::ObjectUnionOf(vec![ClassExpression::Class(
+                build.class("http://example.com/Two"),
+            )]),
+        });
+
+        let mut writer = Vec::new();
+        crate::io::ofn::writer::write(&mut writer, &ont, None).unwrap();
+        let output = String::from_utf8(writer).unwrap();
+
+        assert!(
+            !output.contains("ObjectIntersectionOf("),
+            "a single-operand ObjectIntersectionOf must be unwrapped, not \
+             written invalid:\n{output}"
+        );
+        assert!(
+            !output.contains("ObjectUnionOf("),
+            "a single-operand ObjectUnionOf must be unwrapped, not written \
+             invalid:\n{output}"
+        );
+
+        // The written output must be re-readable by our own OFN reader --
+        // this is the actual `horned-roundtrip` failure mode this test
+        // guards against.
+        let (_, _): (ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>, _) =
+            crate::io::ofn::reader::read(std::io::Cursor::new(&output), Default::default())
+                .expect("written output must be re-parseable as OFN");
+    }
+
     #[cfg(test)]
     mod bubo_test {
         use crate::io::ofn::writer::test::*;

--- a/src/io/ofn/writer/mod.rs
+++ b/src/io/ofn/writer/mod.rs
@@ -70,18 +70,40 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: Write>(
         }
     }
 
-    // Write axioms in order
-    for kind in ComponentKind::all_kinds() {
-        if kind != ComponentKind::OntologyID && kind != ComponentKind::DocIRI {
-            let mut components = ont.i().component_for_kind(kind).collect::<Vec<_>>();
-            components.sort();
-            for component in components {
-                writeln!(
-                    write,
-                    "    {}",
-                    component.as_functional_with_prefixes(mapping)
-                )?;
-            }
+    // The OWL 2 Functional-Style Syntax grammar fixes the order of an
+    // `Ontology(...)` body: `directlyImportsDocuments` (`Import(...)`)
+    // must precede `ontologyAnnotations` (`Annotation(...)`), which in
+    // turn must precede the axioms
+    // (https://www.w3.org/TR/owl2-syntax/#Ontologies -- see also
+    // `Ontology` in `src/grammars/ofn.pest`, which encodes the same
+    // order and rejects anything else). `ComponentKind::all_kinds()`
+    // does not honour this -- `OntologyAnnotation` is declared before
+    // `Import` in the `components!` macro invocation in `model.rs`, so
+    // the naive loop below would write annotations before imports and
+    // produce unparseable output (see
+    // https://github.com/phillord/horned-owl/issues/229). Write
+    // `Import` then `OntologyAnnotation` up front, then fall through to
+    // every other kind in their `all_kinds()` order.
+    let mut other_kinds = ComponentKind::all_kinds();
+    other_kinds.retain(|k| {
+        *k != ComponentKind::OntologyID
+            && *k != ComponentKind::DocIRI
+            && *k != ComponentKind::Import
+            && *k != ComponentKind::OntologyAnnotation
+    });
+    let ordered_kinds = [ComponentKind::Import, ComponentKind::OntologyAnnotation]
+        .into_iter()
+        .chain(other_kinds);
+
+    for kind in ordered_kinds {
+        let mut components = ont.i().component_for_kind(kind).collect::<Vec<_>>();
+        components.sort();
+        for component in components {
+            writeln!(
+                write,
+                "    {}",
+                component.as_functional_with_prefixes(mapping)
+            )?;
         }
     }
 
@@ -143,6 +165,47 @@ mod test {
             output.contains("Annotation(Annotation("),
             "nested annotation was lost in round-trip:\n{output}"
         );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/229
+    // The OFN grammar (and OWL 2 spec) requires `Import(...)` statements to
+    // precede ontology `Annotation(...)`s in an `Ontology(...)` body, but the
+    // writer used to walk `ComponentKind::all_kinds()` in `components!`
+    // macro declaration order, which puts `OntologyAnnotation` before
+    // `Import` -- producing output the reader itself then rejects. Check
+    // both that a written `Import` textually precedes a written
+    // `Annotation`, and that the written bytes reread successfully (the
+    // real-world symptom: a `horned-roundtrip` `reread_fail`).
+    #[test]
+    fn roundtrip_import_before_ontology_annotation() {
+        let resource = "src/ont/owl-functional/manual/import-and-annotation.ofn";
+        let reader = std::fs::File::open(resource)
+            .map(std::io::BufReader::new)
+            .unwrap();
+        let (ont, prefixes): (ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>, _) =
+            crate::io::ofn::reader::read(reader, Default::default()).unwrap();
+
+        let mut writer = Vec::new();
+        crate::io::ofn::writer::write(&mut writer, &ont, Some(&prefixes)).unwrap();
+        let output = String::from_utf8(writer.clone()).unwrap();
+
+        let import_pos = output
+            .find("Import(")
+            .expect("Import(...) missing from written output");
+        let annotation_pos = output
+            .find("Annotation(rdfs:label")
+            .expect("ontology Annotation(...) missing from written output");
+        assert!(
+            import_pos < annotation_pos,
+            "Import must precede the ontology Annotation in OFN output:\n{output}"
+        );
+
+        crate::io::ofn::reader::read::<
+            RcStr,
+            ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>,
+            _,
+        >(std::io::Cursor::new(&writer), Default::default())
+        .expect("written OFN with both Import and ontology Annotation must reread cleanly");
     }
 
     #[cfg(test)]

--- a/src/io/ofn/writer/mod.rs
+++ b/src/io/ofn/writer/mod.rs
@@ -5,7 +5,9 @@ use curie::PrefixMapping;
 use crate::error::HornedError;
 use crate::model::Component;
 use crate::model::ComponentKind;
+use crate::model::DifferentIndividuals;
 use crate::model::ForIRI;
+use crate::model::SameIndividual;
 use crate::ontology::component_mapped::ComponentMappedOntology;
 use crate::ontology::indexed::ForIndex;
 
@@ -13,6 +15,32 @@ mod as_functional;
 
 pub use self::as_functional::AsFunctional;
 pub use self::as_functional::Functional;
+
+/// Whether `component` has enough operands to be legal OWL Functional-Style
+/// Syntax.
+///
+/// `SameIndividual` and `DifferentIndividuals` both require two or more
+/// individuals in the OWL 2 structural grammar
+/// (<https://www.w3.org/TR/owl2-syntax/#Individual_Equality>,
+/// <https://www.w3.org/TR/owl2-syntax/#Individual_Inequality>) --
+/// `src/grammars/ofn.pest`'s `SameIndividual`/`DifferentIndividuals`
+/// productions require `Individual{2, }` accordingly. Real-world RDF/XML has
+/// been observed (see
+/// [#214](https://github.com/phillord/horned-owl/issues/214)) to contain an
+/// `owl:AllDifferent` with a single `owl:distinctMembers` entry -- horned-
+/// owl's RDF reader accepts this leniently into the model as a one-member
+/// `DifferentIndividuals`. Such an axiom asserts nothing (there is no second
+/// individual to differ from), so it is semantically vacuous, but writing it
+/// out verbatim as OFN produces `DifferentIndividuals(<one IRI>)`, which the
+/// grammar's own reader then rejects. Skip writing these degenerate axioms
+/// rather than emit syntax our own reader can't parse back.
+fn has_writable_arity<A: ForIRI>(component: &Component<A>) -> bool {
+    match component {
+        Component::SameIndividual(SameIndividual(v)) => v.len() >= 2,
+        Component::DifferentIndividuals(DifferentIndividuals(v)) => v.len() >= 2,
+        _ => true,
+    }
+}
 
 /// Write an Ontology to `write`, using the given `PrefixMapping`.
 ///
@@ -76,6 +104,9 @@ pub fn write<A: ForIRI, AA: ForIndex<A>, W: Write>(
             let mut components = ont.i().component_for_kind(kind).collect::<Vec<_>>();
             components.sort();
             for component in components {
+                if !has_writable_arity(&component.component) {
+                    continue;
+                }
                 writeln!(
                     write,
                     "    {}",
@@ -143,6 +174,58 @@ mod test {
             output.contains("Annotation(Annotation("),
             "nested annotation was lost in round-trip:\n{output}"
         );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/214
+    // Real-world RDF/XML (e.g. the ACGT-MO ontology from the BioPortal
+    // corpus) has been observed to contain an `owl:AllDifferent` with a
+    // single `owl:distinctMembers` entry. Horned-owl's RDF reader accepts
+    // this leniently, producing a one-member `DifferentIndividuals` axiom in
+    // the model -- but the OFN grammar requires `Individual{2, }`, so writing
+    // it out verbatim produced `DifferentIndividuals(<one IRI>)`, which the
+    // writer's own reader then rejected (the real-world symptom: a
+    // `horned-roundtrip` `reread_fail`). Since such an axiom asserts nothing,
+    // the writer now drops it instead. A well-formed (2+ member)
+    // `DifferentIndividuals` must still be written normally.
+    #[test]
+    fn degenerate_different_individuals_is_dropped_not_written_invalid() {
+        use crate::model::Build;
+        use crate::model::DifferentIndividuals;
+        use crate::model::MutableOntology;
+
+        let build = Build::<RcStr>::new();
+        let mut ont: ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>> =
+            ComponentMappedOntology::new();
+        ont.insert(DifferentIndividuals(vec![
+            build
+                .named_individual("http://example.com/HERATrial")
+                .into(),
+        ]));
+        ont.insert(DifferentIndividuals(vec![
+            build.named_individual("http://example.com/A").into(),
+            build.named_individual("http://example.com/B").into(),
+        ]));
+
+        let mut writer = Vec::new();
+        crate::io::ofn::writer::write(&mut writer, &ont, None).unwrap();
+        let output = String::from_utf8(writer).unwrap();
+
+        assert!(
+            !output.contains("HERATrial"),
+            "degenerate single-member DifferentIndividuals should have been \
+             dropped, but was written:\n{output}"
+        );
+        assert!(
+            output.contains("DifferentIndividuals(<http://example.com/A> <http://example.com/B>)"),
+            "well-formed DifferentIndividuals should still be written:\n{output}"
+        );
+
+        // The written output must be re-readable by our own OFN reader --
+        // this is the actual `horned-roundtrip` failure mode this test
+        // guards against.
+        let (_, _): (ComponentMappedOntology<RcStr, AnnotatedComponent<RcStr>>, _) =
+            crate::io::ofn::reader::read(std::io::Cursor::new(&output), Default::default())
+                .expect("written output must be re-parseable as OFN");
     }
 
     #[cfg(test)]

--- a/src/io/omn/writer/as_manchester.rs
+++ b/src/io/omn/writer/as_manchester.rs
@@ -75,13 +75,34 @@ pub(crate) fn render_iri_to_string(iri: &str, pm: Option<&PrefixMapping>) -> Str
         // `http://e/onto`) shrinks `http://e/onto#A` to `#A`, which is also
         // invalid — emit the full `<iri>` form instead.
         if is_valid_manchester_local(local) {
-            // `add_prefix("", ns)` stores "" in the prefix *mapping* (not the
-            // default slot), so `shrink_iri` returns a `Curie { prefix: Some(""), .. }`
-            // which `Display` formats as ":local". Strip the leading ':' to get the
-            // bare local name for the default prefix.
+            if !s.contains(':') {
+                // No ':' anywhere in `s` means `shrink_iri` matched the `curie`
+                // crate's *separate* "default slot" (`set_default`, e.g. what
+                // the OWL/XML reader derives from a bare `ontologyIRI`
+                // attribute with no explicit `<Prefix name="" .../>`), which
+                // yields `Curie { prefix: None, .. }` — `Display` writes only
+                // the bare reference, with no colon at all. That's
+                // indistinguishable in isolation from a genuine Manchester
+                // `SimpleIRI`, but there is no corresponding `Prefix: : <iri>`
+                // declaration to back it: `curie` exposes no getter for the
+                // default slot, so the writer's header loop (which only
+                // iterates `mapping.mappings()`) can never see it. Emitting
+                // the bare local name here would produce a `SimpleIRI` the
+                // reader cannot resolve (issue #233) — fall back to the full
+                // `<iri>` form instead, same as the other unrenderable shapes
+                // below.
+                return format!("<{iri}>");
+            }
+            // `s` contains a ':', so `shrink_iri` matched a genuine *named*
+            // mapping-table entry (`Curie { prefix: Some(_), .. }`), backed by
+            // a real `Prefix: name: <iri>` header line from `mapping.mappings()`.
             return if let Some(stripped) = s.strip_prefix(':') {
+                // Empty name (`add_prefix("", ns)`, e.g. an explicit
+                // `Prefix: : <iri>`) — Display gives ":local"; strip the
+                // leading ':' for the bare Manchester SimpleIRI form.
                 stripped.to_owned()
             } else {
+                // Non-empty name, e.g. "ex:Dog" — already the correct form.
                 s
             };
         }
@@ -963,6 +984,31 @@ mod tests {
         assert_eq!(
             c.as_manchester_with_prefixes(&pm).to_string(),
             "<http://ex/a/b>"
+        );
+    }
+
+    #[test]
+    fn default_slot_without_named_empty_prefix_falls_back_to_full_iri() {
+        // `set_default` (the `curie` crate's separate "default slot", e.g.
+        // what `owx::reader` derives from an `ontologyIRI` attribute with no
+        // explicit `<Prefix name="" .../>`) is a DIFFERENT mechanism from
+        // `add_prefix("", ns)` (a genuine, enumerable "" entry in the prefix
+        // mapping). `shrink_iri` matches the default slot first and yields a
+        // bare local name with no leading ':' -- indistinguishable in isolation
+        // from a real Manchester `SimpleIRI`, but with no `Prefix: : <iri>`
+        // declaration to back it (the writer's header loop only iterates
+        // `mapping.mappings()`, which a `set_default`-only entry never joins).
+        // Emitting the bare name here would produce output the reader cannot
+        // resolve (issue #233) -- it must fall back to the full `<iri>` form,
+        // exactly like the `renders_named_class` (no prefix mapping at all)
+        // case above.
+        let b = Build::new_rc();
+        let c = b.class("http://ex.org/onto#Widget");
+        let mut pm = curie::PrefixMapping::default();
+        pm.set_default("http://ex.org/onto#");
+        assert_eq!(
+            c.as_manchester_with_prefixes(&pm).to_string(),
+            "<http://ex.org/onto#Widget>"
         );
     }
 

--- a/src/io/omn/writer/mod.rs
+++ b/src/io/omn/writer/mod.rs
@@ -1469,6 +1469,61 @@ mod tests {
         assert_eq!(orig, got, "anon annotation value did not round-trip\n{s}");
     }
 
+    // Regression test for https://github.com/phillord/horned-owl/issues/236
+    // `en-scotland` (language `en` + the 8-alphanumeric variant subtag
+    // `scotland`, no script/region present) is a real BCP-47 language tag
+    // found in the FOODON corpus ontology, on an
+    // `oboInOwl:hasExactSynonym "neep"@en-scotland` annotation. The
+    // `bcp47.pest` grammar's `BCP47_Script`/`BCP47_Region` productions used
+    // to greedily consume the first four letters of `scotland` (`scot`) as
+    // if it were a script subtag, stranding `land` with no leading `-` and
+    // making the tag unparseable -- the writer emits the tag verbatim, so
+    // its own reader then rejected its own output (the real-world symptom:
+    // a `horned-roundtrip` `reread_fail`).
+    #[test]
+    fn language_tag_with_long_unhyphenated_variant_subtag_roundtrips() {
+        use crate::io::omn::read_with_build;
+        use std::io::BufReader;
+
+        let b = Build::new_rc();
+        let mut pm = PrefixMapping::default();
+        pm.add_prefix("ex", "http://ex/").unwrap();
+        pm.add_prefix("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
+            .unwrap();
+        let mut o = SetOntology::new_rc();
+        o.insert(AnnotationAssertion {
+            subject: AnnotationSubject::IRI(b.iri("http://ex/A")),
+            ann: Annotation {
+                ap: b.annotation_property("http://www.w3.org/2000/01/rdf-schema#label"),
+                av: AnnotationValue::Literal(Literal::Language {
+                    literal: "neep".to_string(),
+                    lang: "en-scotland".to_string(),
+                }),
+                ann: Default::default(),
+            },
+        });
+        let amo = into_amo(o.clone());
+        let mut out = Vec::<u8>::new();
+        write(&mut out, &amo, Some(&pm)).unwrap();
+        let s = String::from_utf8(out.clone()).unwrap();
+        assert!(
+            s.contains("\"neep\"@en-scotland"),
+            "expected the language tag to be written verbatim, got:\n{s}"
+        );
+
+        // The written output must be re-readable by our own OMN reader --
+        // this is the actual `horned-roundtrip` failure mode this test
+        // guards against.
+        let (parsed, _): (SetOntology<_>, PrefixMapping) =
+            read_with_build(BufReader::new(&out[..]), &b).unwrap_or_else(|e| {
+                panic!("written OMN with @en-scotland must reread cleanly: {e}\n{s}")
+            });
+        let orig: std::collections::BTreeSet<_> = o.iter().map(|ac| ac.component.clone()).collect();
+        let got: std::collections::BTreeSet<_> =
+            parsed.iter().map(|ac| ac.component.clone()).collect();
+        assert_eq!(orig, got, "language tag did not round-trip\n{s}");
+    }
+
     #[cfg(test)]
     mod bubo_test {
         use crate::io::omn::writer::tests::*;

--- a/src/io/owx/reader.rs
+++ b/src/io/owx/reader.rs
@@ -142,7 +142,7 @@ fn decode_expand_curie_maybe<'a, A: ForIRI, R: BufRead>(
     #[cfg(not(feature = "encoding"))]
     match r.reader.decoder().decode(val) {
         Ok(curie) => {
-            let cur = expand_curie_maybe(r, curie);
+            let cur = expand_curie_or_base_maybe(r, curie);
             Ok(cur)
         }
         Err(e) => Err(HornedError::from(e)),
@@ -159,6 +159,29 @@ fn expand_curie_maybe<'a, A: ForIRI, R: BufRead>(
         Ok(n) => Cow::Owned(n),
         // Else assume it's a complete URI
         Err(_e) => val,
+    }
+}
+
+/// Like [`expand_curie_maybe`], except a fragment-only value (starting
+/// with `#`) is resolved against the ontology's base IRI rather than the
+/// CURIE default prefix. Mirrors the identical guard in `get_iri_value`
+/// (issue #212): the default/empty prefix may itself already end in
+/// `#`, which would otherwise double up when concatenated with a
+/// `#fragment` value (`prefix#` + `#fragment` = `prefix##fragment`).
+/// `get_iri_value` special-cases this for the `IRI="..."` *attribute*
+/// form; this does the same for the `<IRI>text</IRI>` *element content*
+/// form (see issue #226 -- the attribute path was fixed, this sibling
+/// path wasn't).
+fn expand_curie_or_base_maybe<'a, A: ForIRI, R: BufRead>(
+    r: &mut Read<A, R>,
+    val: Cow<'a, str>,
+) -> Cow<'a, str> {
+    if val.starts_with('#')
+        && let Some(base) = r.base_iri.clone()
+    {
+        Cow::Owned(format!("{base}{val}"))
+    } else {
+        expand_curie_maybe(r, val)
     }
 }
 
@@ -2648,5 +2671,35 @@ pub mod test {
             read_with_build(&mut owx.as_bytes(), &b, Default::default()).unwrap();
         let dc = ont.i().declare_class().next().unwrap();
         assert_eq!(dc.0.0.to_string(), "http://ontriscal#MyClass");
+    }
+
+    // Regression test for #226: the same doubled-## bug as #212
+    // (relative_iri_with_empty_prefix_no_double_hash above), but for a
+    // fragment-only IRI given as <IRI>#local</IRI> *element content*
+    // (e.g. an AnnotationAssertion subject) rather than an IRI="#local"
+    // *attribute*. The #212 fix only covered the attribute form.
+    #[test]
+    fn relative_iri_element_content_with_empty_prefix_no_double_hash() {
+        let owx = r##"<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="http://ontriscal"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="http://ontriscal">
+    <Prefix name="" IRI="http://ontriscal#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+    <Declaration>
+        <Class IRI="#MyClass"/>
+    </Declaration>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#MyClass</IRI>
+        <Literal>a comment</Literal>
+    </AnnotationAssertion>
+</Ontology>"##;
+        let b = Build::new_rc();
+        let (ont, _): (ComponentMappedOntology<RcStr, RcAnnotatedComponent>, _) =
+            read_with_build(&mut owx.as_bytes(), &b, Default::default()).unwrap();
+        let assertion = ont.i().annotation_assertion().next().unwrap();
+        assert_eq!(assertion.subject.to_string(), "http://ontriscal#MyClass");
     }
 }

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -242,8 +242,15 @@ where
     let id = o.i().the_ontology_id_or_default();
     iri_maybe(&mut elem, "xml:base", &id.iri);
 
-    // Render XML Namespaces.
+    // Render XML Namespaces. The empty/default CURIE prefix (`name=""`) has
+    // no valid `xmlns:`-attribute spelling -- `xmlns:` with no local name
+    // is not legal XML -- and the default namespace is already bound to OWL
+    // above, so skip it here; it's still available for CURIE expansion via
+    // the `<Prefix name="" IRI="..."/>` element rendered separately below.
     for pre in m.mappings() {
+        if pre.0.is_empty() {
+            continue;
+        }
         elem.push_attribute((format!("xmlns:{}", pre.0).as_bytes(), pre.1.as_bytes()));
     }
     iri_maybe(&mut elem, "ontologyIRI", &id.iri);
@@ -1084,6 +1091,25 @@ mod test {
         let s = roundtrip_to_string(include_str!("../../ont/owl-xml/ont.owx"));
 
         assert!(s.contains("xmlns:xsd"));
+    }
+
+    // Regression test for #227: an ontology with an empty/default CURIE
+    // prefix (`<Prefix name="" IRI="..."/>`) used to be written back out
+    // with an invalid `xmlns:="..."` namespace-declaration attribute
+    // (colon with no local name), which is not legal XML and made the
+    // written file fail to reread. Assert the writer no longer emits that
+    // attribute, and that the file survives a full write-then-reread
+    // round trip.
+    #[test]
+    fn test_empty_prefix_no_invalid_xmlns_attribute() {
+        let s = roundtrip_to_string(include_str!("../../ont/owl-xml/manual/empty-prefix.owx"));
+
+        assert!(
+            !s.contains("xmlns:=\""),
+            "writer emitted an invalid xmlns:=\"...\" attribute: {s}"
+        );
+
+        assert_round(include_str!("../../ont/owl-xml/manual/empty-prefix.owx"));
     }
 
     #[test]

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -133,22 +133,94 @@ impl<A: ForIRI> NodeGenerator<A> {
     }
 }
 
+/// Percent-encode characters that are never legal, unescaped, inside an
+/// IRI per RFC 3987 -- regardless of where in the IRI they occur -- but
+/// which horned-owl's readers (in particular the lenient OWL/XML reader)
+/// will happily accept verbatim from "wild" real-world ontologies.
+///
+/// Left untouched: anything already valid unescaped in an IRI (ASCII
+/// unreserved/gen-delims/sub-delims characters, existing `%XX` escapes,
+/// and non-ASCII `ucschar`/`iprivate` code points, which RFC 3987 permits
+/// directly). `[` and `]` are technically valid only inside an IPv6
+/// `IP-literal` host, a case essentially never seen in ontology IRIs, so
+/// they are unconditionally escaped here along with the other characters
+/// that RFC 3987 never permits unescaped anywhere.
+///
+/// Without this, an IRI such as `.../untitled-ontology-11#KB-CH[R]-8-5Cell`
+/// (see issue #232, found in a real corpus ontology) is written unescaped
+/// into `rdf:about`/`rdf:resource` attributes. The result is syntactically
+/// valid XML (attribute values aren't IRI-checked by XML itself) but not a
+/// valid IRI, so strict RDF/XML parsers -- including the oxrdfio-backed
+/// reader horned-owl itself uses to reread its own output -- reject it,
+/// breaking the read/write/reread round trip.
+fn escape_invalid_iri_chars(s: &str) -> std::borrow::Cow<'_, str> {
+    fn needs_escaping(c: char) -> bool {
+        matches!(
+            c,
+            '\u{0}'
+                ..='\u{1F}'
+                    | '\u{7F}'
+                    | ' '
+                    | '"'
+                    | '<'
+                    | '>'
+                    | '\\'
+                    | '^'
+                    | '`'
+                    | '{'
+                    | '|'
+                    | '}'
+                    | '['
+                    | ']'
+        )
+    }
+
+    if !s.contains(needs_escaping) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if needs_escaping(c) {
+            let mut buf = [0u8; 4];
+            for byte in c.encode_utf8(&mut buf).as_bytes() {
+                out.push('%');
+                out.push_str(&format!("{byte:02X}"));
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+/// Build a [`PNamedNode`] from a horned-owl [`IRI`], percent-encoding any
+/// characters that would otherwise make the serialized IRI invalid (see
+/// [`escape_invalid_iri_chars`]).
+fn escaped_named_node<A: ForIRI>(iri: &IRI<A>) -> PNamedNode<A> {
+    let raw = iri.underlying();
+    match escape_invalid_iri_chars(&raw) {
+        std::borrow::Cow::Borrowed(_) => PNamedNode::new(raw),
+        std::borrow::Cow::Owned(escaped) => PNamedNode::new(A::from_str(&escaped)),
+    }
+}
+
 /// Convertors from Pretty RDF components and equivalent Horned-OWL model
 impl<A: ForIRI> From<&IRI<A>> for PTerm<A> {
     fn from(iri: &IRI<A>) -> Self {
-        PNamedNode::new(iri.underlying()).into()
+        escaped_named_node(iri).into()
     }
 }
 
 impl<A: ForIRI> From<&IRI<A>> for PNamedNode<A> {
     fn from(iri: &IRI<A>) -> Self {
-        PNamedNode::new(iri.underlying())
+        escaped_named_node(iri)
     }
 }
 
 impl<A: ForIRI> From<&IRI<A>> for PNamedOrBlankNode<A> {
     fn from(iri: &IRI<A>) -> Self {
-        let nn = PNamedNode::new(iri.underlying());
+        let nn = escaped_named_node(iri);
         nn.into()
     }
 }
@@ -1944,6 +2016,42 @@ mod test {
 <http://www.example.com/iri> <http://www.w3.org/2002/07/owl#versionIRI> <http://www.example.com/viri> .
 <http://www.example.com/iri#C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 "#
+        );
+    }
+
+    #[test]
+    fn iri_with_rfc3987_invalid_chars_round_trips() {
+        // Real-world ontologies (e.g. corpus file `MCCL`, see issue #232) can
+        // contain IRIs with characters, like `[` and `]`, that are never
+        // legal unescaped in an IRI per RFC 3987. horned-owl's OWL/XML
+        // reader is lenient and accepts such text verbatim, so the writer
+        // must percent-encode it to produce valid, rereadable RDF/XML.
+        //
+        // Note the recovered IRI is percent-encoded (`%5B`/`%5D`) rather
+        // than byte-identical to the original raw `[`/`]` text -- that's
+        // expected and correct: `[`/`]` are gen-delims, so a compliant IRI
+        // reader must not silently decode their percent-encoded form back
+        // to the literal bracket, as that would change the IRI's syntactic
+        // structure. What matters is that the reread no longer fails.
+        let b = Build::new_rc();
+        let mut ont_orig = SetOntology::new_rc();
+        ont_orig.insert(DeclareClass(Class(
+            b.iri("http://example.com/o#KB-CH[R]-8-5Cell"),
+        )));
+
+        let amo: ComponentMappedOntology<RcStr, Rc<AnnotatedComponent<RcStr>>> = ont_orig.into();
+        let mut buf = Vec::new();
+        write(&mut buf, &amo).expect("write should not fail on an invalid-IRI-char class");
+
+        let ont_round = read_ok(&mut &buf[..]);
+        let expected_class = Class(b.iri("http://example.com/o#KB-CH%5BR%5D-8-5Cell"));
+        assert!(
+            ont_round.iter().any(|ac| matches!(
+                &ac.component,
+                Component::DeclareClass(DeclareClass(c)) if *c == expected_class
+            )),
+            "rereading the written RDF/XML should recover the class declaration \
+             (percent-encoded), got: {ont_round:#?}"
         );
     }
 

--- a/src/ont/owl-functional/manual/import-and-annotation.ofn
+++ b/src/ont/owl-functional/manual/import-and-annotation.ofn
@@ -1,0 +1,17 @@
+Prefix(:=<http://www.example.com/iri#>)
+Prefix(o:=<http://www.example.com/iri#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+Ontology(<http://www.example.com/iri>
+
+Import(<http://www.example.com/other-iri>)
+
+Annotation(rdfs:label "An ontology with both an import and an ontology annotation"@en)
+
+Declaration(Class(o:A))
+
+)

--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -150,6 +150,28 @@ impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for DeclarationMappedIndex
                     return None;
                 }
 
+                // AnnotationProperty/ObjectProperty (or DataProperty)
+                // punning is not legal in OWL 2 DL, but appears in
+                // real-world ontologies. Unlike the Class/NamedIndividual
+                // case above (which is tracked via `puns`, consumed by
+                // `kind_prefer_punned_individual`), there is no separate
+                // "prefer" accessor for this combination, so without a
+                // fixed priority here, declaration_kind() resolution
+                // would depend on insertion order -- which itself
+                // depends on incidental detail such as the order axioms
+                // appear in a source document, and does not survive a
+                // write/read round trip. Give ObjectProperty/DataProperty
+                // priority over AnnotationProperty so the same IRI always
+                // resolves the same way regardless of insertion order.
+                if ne == NamedEntityKind::AnnotationProperty
+                    && matches!(
+                        self.kinds.get(&iri),
+                        Some(NamedEntityKind::ObjectProperty) | Some(NamedEntityKind::DataProperty)
+                    )
+                {
+                    return None;
+                }
+
                 // Save the kind
                 let s = self.kinds.insert(iri.clone(), ne);
 
@@ -298,6 +320,77 @@ mod test {
         assert_eq!(
             d.declaration_kind_prefer_punned_individual(&iri),
             Some(NamedOWLEntityKind::NamedIndividual)
+        );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/228
+    //
+    // An IRI declared as both AnnotationProperty and ObjectProperty (illegal
+    // punning under OWL 2 DL, but seen in real-world ontologies) must
+    // resolve to the same declaration_kind() regardless of which
+    // declaration was inserted first -- otherwise round-tripping through a
+    // writer that reorders the declarations changes the resolved kind and
+    // breaks reread.
+    #[test]
+    fn test_annotation_object_property_pun_order_independent() {
+        let b = Build::new_rc();
+        let iri = b.iri("http://www.example.com/p");
+        let ap: AnnotatedComponent<_> = {
+            let ap: NamedOWLEntity<_> = b.annotation_property("http://www.example.com/p").into();
+            ap.into()
+        };
+        let op: AnnotatedComponent<_> = {
+            let op: NamedOWLEntity<_> = b.object_property("http://www.example.com/p").into();
+            op.into()
+        };
+
+        // AnnotationProperty declared first, ObjectProperty second.
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(ap.clone().into());
+        d.index_insert(op.clone().into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::ObjectProperty)
+        );
+
+        // ObjectProperty declared first, AnnotationProperty second.
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(op.into());
+        d.index_insert(ap.into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::ObjectProperty)
+        );
+    }
+
+    // Same as above but for DataProperty rather than ObjectProperty.
+    #[test]
+    fn test_annotation_data_property_pun_order_independent() {
+        let b = Build::new_rc();
+        let iri = b.iri("http://www.example.com/p");
+        let ap: AnnotatedComponent<_> = {
+            let ap: NamedOWLEntity<_> = b.annotation_property("http://www.example.com/p").into();
+            ap.into()
+        };
+        let dp: AnnotatedComponent<_> = {
+            let dp: NamedOWLEntity<_> = b.data_property("http://www.example.com/p").into();
+            dp.into()
+        };
+
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(ap.clone().into());
+        d.index_insert(dp.clone().into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::DataProperty)
+        );
+
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(dp.into());
+        d.index_insert(ap.into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::DataProperty)
         );
     }
 }


### PR DESCRIPTION
## Summary

Twelve independently-verified round-trip bugs found via `horned-roundtrip` corpus testing, each fixed on its own branch and merged here:

- #226 — OWL/XML reader: doubled `#` in `<IRI>text</IRI>` element content
- #227 — OWL/XML writer: invalid `xmlns:="..."` for the empty/default prefix
- #228 — order-dependent `AnnotationProperty`/`ObjectProperty` pun resolution
- #229 — OFN writer: `Import` written after ontology `Annotation`
- #230 — OFN writer: invalid `AbbreviatedIRI` for the default/empty CURIE prefix
- #231 — OFN writer: abbreviates IRIs with an invalid `PN_LOCAL` local name
- #214 — OFN writer: degenerate single-member `SameIndividual`/`DifferentIndividuals`
- #232 — RDF/XML writer: unescaped RFC 3987-invalid IRI characters
- #233 — OMN writer: invalid bare `SimpleIRI` for curie's default-slot prefix match
- #234 — OFN writer: unescaped RFC 3987-invalid IRI characters
- #235 — OFN writer: degenerate single-operand `ObjectIntersectionOf`/`ObjectUnionOf`
- #236 — BCP-47 grammar: greedy script/region match truncating long variant subtags

Each fix has its own regression test, confirmed to fail without the fix and pass with it.

## Impact

Full corpus round-trip (`reread_fail` outcome): **447 → 36** (92% reduction), zero new panics/read_fail/write_fail throughout. One case (`HO`, issue #237) was investigated and correctly left unfixed — it's a genuine missing-declaration gap in the source ontology, not a narrow encoding bug, and forcing a fix would require a disproportionately large change.

## Performance

Benchmarked against `devel` (`bench-compare-branches`). Reading, iteration, and in-memory structures are unaffected (within ~0-5% noise). RDF-family writers (RDF/XML, Turtle, N-Triples) show a real, consistent slowdown (+8-27% depending on format) from the new IRI-escaping check added on the shared IRI-to-term conversion path (#232) — small in absolute terms (sub-millisecond even at 10,000 axioms) and understood as the direct cost of producing valid, rereadable output for previously-broken cases.

## Test plan

- [x] Each fix's own regression test verified red→green
- [x] Full workspace `cargo test --lib --bins --tests -- --skip integration` clean (1371 tests)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Full corpus round-trip rerun confirming the 447→36 reduction with zero regressions