### PR TITLE
Fix order-dependent AnnotationProperty/ObjectProperty pun resolution

### DIFF
--- a/src/ontology/declaration_mapped.rs
+++ b/src/ontology/declaration_mapped.rs
@@ -150,6 +150,19 @@ impl<A: ForIRI, AA: ForIndex<A>> OntologyIndex<A, AA> for DeclarationMappedIndex
                     return None;
                 }
 
+                // AnnotationProperty/ObjectProperty (or DataProperty)
+                // punning is not legal in OWL 2 DL, but happens. We
+                // pick Object or DataProperty here, the resolution
+                // will depend on implementation details.
+                if ne == NamedEntityKind::AnnotationProperty
+                    && matches!(
+                        self.kinds.get(&iri),
+                        Some(NamedEntityKind::ObjectProperty) | Some(NamedEntityKind::DataProperty)
+                    )
+                {
+                    return None;
+                }
+
                 // Save the kind
                 let s = self.kinds.insert(iri.clone(), ne);
 
@@ -298,6 +311,77 @@ mod test {
         assert_eq!(
             d.declaration_kind_prefer_punned_individual(&iri),
             Some(NamedOWLEntityKind::NamedIndividual)
+        );
+    }
+
+    // Regression test for https://github.com/phillord/horned-owl/issues/228
+    //
+    // An IRI declared as both AnnotationProperty and ObjectProperty (illegal
+    // punning under OWL 2 DL, but seen in real-world ontologies) must
+    // resolve to the same declaration_kind() regardless of which
+    // declaration was inserted first -- otherwise round-tripping through a
+    // writer that reorders the declarations changes the resolved kind and
+    // breaks reread.
+    #[test]
+    fn test_annotation_object_property_pun_order_independent() {
+        let b = Build::new_rc();
+        let iri = b.iri("http://www.example.com/p");
+        let ap: AnnotatedComponent<_> = {
+            let ap: NamedOWLEntity<_> = b.annotation_property("http://www.example.com/p").into();
+            ap.into()
+        };
+        let op: AnnotatedComponent<_> = {
+            let op: NamedOWLEntity<_> = b.object_property("http://www.example.com/p").into();
+            op.into()
+        };
+
+        // AnnotationProperty declared first, ObjectProperty second.
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(ap.clone().into());
+        d.index_insert(op.clone().into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::ObjectProperty)
+        );
+
+        // ObjectProperty declared first, AnnotationProperty second.
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(op.into());
+        d.index_insert(ap.into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::ObjectProperty)
+        );
+    }
+
+    // Same as above but for DataProperty rather than ObjectProperty.
+    #[test]
+    fn test_annotation_data_property_pun_order_independent() {
+        let b = Build::new_rc();
+        let iri = b.iri("http://www.example.com/p");
+        let ap: AnnotatedComponent<_> = {
+            let ap: NamedOWLEntity<_> = b.annotation_property("http://www.example.com/p").into();
+            ap.into()
+        };
+        let dp: AnnotatedComponent<_> = {
+            let dp: NamedOWLEntity<_> = b.data_property("http://www.example.com/p").into();
+            dp.into()
+        };
+
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(ap.clone().into());
+        d.index_insert(dp.clone().into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::DataProperty)
+        );
+
+        let mut d = DeclarationMappedIndex::new_rc();
+        d.index_insert(dp.into());
+        d.index_insert(ap.into());
+        assert_eq!(
+            d.declaration_kind(&iri),
+            Some(NamedOWLEntityKind::DataProperty)
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #228. Illegal-but-real-world `AnnotationProperty`/`ObjectProperty` (or `DataProperty`) punning resolved via last-write-wins over a `HashMap`, with no fixed priority (unlike the existing Class/NamedIndividual pun handling, which has one) — so which kind won depended on insertion order, which an RDF/XML writer doesn't preserve. Gives Object/DataProperty priority over AnnotationProperty unconditionally, so the same IRI always resolves the same way regardless of insertion order.

## Test plan

- [x] `test_annotation_object_property_pun_order_independent` and `test_annotation_data_property_pun_order_independent` regression tests added, confirmed to fail without the fix and pass with it
- [x] Full workspace `cargo test --lib --bins --tests -- --skip integration` clean (1361 tests)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --check` clean