### PR TITLE
Strip invalid '_:' prefix from rdf:nodeID attribute values

### DIFF
--- a/horned-pretty-rdf/src/lib.rs
+++ b/horned-pretty-rdf/src/lib.rs
@@ -965,6 +965,12 @@ where
         }
     }
 
+    /// Strip a blank node label's leading `_:`, if present, for use as an
+    /// `rdf:nodeID` attribute value (issue #251).
+    fn nodeid_attr_value(bn: &PBlankNode<A>) -> &str {
+        bn.as_ref().strip_prefix("_:").unwrap_or(bn.as_ref())
+    }
+
     fn bytes_start_iri<'a>(&mut self, nn: &'a PNamedNode<A>) -> BytesStart<'a> {
         let (iri_protocol_and_host, iri_qname) = nn.split_iri();
         if let Some(iri_ns_prefix) = &self.config.prefix.get(iri_protocol_and_host) {
@@ -990,7 +996,7 @@ where
                 if let PNamedOrBlankNode::BlankNode(bn) = &typ.subject
                     && chunk.object_count(bn) > 1
                 {
-                    bs.push_attribute(("rdf:nodeID", bn.as_ref()));
+                    bs.push_attribute(("rdf:nodeID", Self::nodeid_attr_value(bn)));
                 }
                 Some(bs)
             } else {
@@ -1120,7 +1126,7 @@ where
                         (None, None) => {}
                     }
                 }
-                property_open.push_attribute(("rdf:nodeID", bn.as_ref()));
+                property_open.push_attribute(("rdf:nodeID", Self::nodeid_attr_value(bn)));
                 self.write_start(Event::Start(property_open))
                     .map_err(map_err)?;
             }

--- a/src/io/rdf/writer.rs
+++ b/src/io/rdf/writer.rs
@@ -2043,6 +2043,49 @@ mod test {
         );
     }
 
+    // Regression test for https://github.com/phillord/horned-owl/issues/251:
+    // a `_:`-prefixed anonymous individual (see `nodeid_attr_value` in
+    // horned-pretty-rdf) referenced more than once, forcing an explicit
+    // `rdf:nodeID` attribute.
+    #[test]
+    fn shared_anonymous_individual_with_underscore_prefix_round_trips() {
+        let b = Build::new_rc();
+        let mut ont = ComponentMappedOntology::new_rc();
+        let anon = b.anon("_:genid1");
+        ont.insert(ObjectPropertyAssertion {
+            ope: b.object_property("http://example.com/p1").into(),
+            from: b.named_individual("http://example.com/s1").into(),
+            to: anon.clone().into(),
+        });
+        ont.insert(ObjectPropertyAssertion {
+            ope: b.object_property("http://example.com/p2").into(),
+            from: b.named_individual("http://example.com/s2").into(),
+            to: anon.into(),
+        });
+
+        let mut buf = Vec::new();
+        write(&mut buf, &ont).expect("write should not fail");
+        let s = String::from_utf8(buf.clone()).unwrap();
+        assert!(
+            !s.contains("nodeID=\"_:"),
+            "rdf:nodeID must never contain a colon, got:\n{s}"
+        );
+
+        // The written output must be re-readable -- this is the actual
+        // horned-roundtrip failure mode this test guards against. (Not
+        // using `read_ok` here: it also asserts the parse is *complete* in
+        // the OWL-axiom-mapping sense, which is a separate concern from
+        // this test -- a bare shared blank node with no type declaration
+        // isn't guaranteed to map back to a recognised axiom shape. What
+        // matters here is that the RDF/XML syntax itself is valid.)
+        let result = crate::io::rdf::reader::read(&mut &buf[..], Default::default());
+        assert!(
+            result.is_ok(),
+            "written RDF/XML must be syntactically valid to reread, got: {:?}",
+            result.err()
+        );
+    }
+
     #[test]
     fn single_member_different_individuals_does_not_panic() {
         let b = Build::new_rc();


### PR DESCRIPTION
## Summary
Some real-world OWL/XML has AnonymousIndividual nodeID attributes that already carry a `_:` prefix (`nodeID="_:genid2147483648"`), which the lenient OWL/XML reader stores verbatim. When such an individual is referenced more than once, the RDF/XML writer emits an explicit `rdf:nodeID` attribute to link the shared references -- and that attribute must never contain a colon, so the pre-existing `_:` has to be stripped rather than written straight through.

Fixes #251

## Test plan
- Added a regression test (`shared_anonymous_individual_with_underscore_prefix_round_trips`) exercising a shared, `_:`-prefixed anonymous individual referenced twice, asserting the written `rdf:nodeID` contains no colon and rereads successfully.
- Verified red before fix, green after.
- `cargo test --lib --bins --tests -- --skip integration`: 1397 passed / 0 failed.
- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets`: only pre-existing, unrelated warnings in `src/io/obo/`.
- Confirmed against the real `QUANTUM-MIND.owx` corpus file that originally surfaced this: RDF/XML reread now OK.