### PR TITLE
Recognise the legacy OWL 1.1 owl:AntisymmetricProperty term in the RDF reader

### DIFF
--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -1983,7 +1983,7 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                 [
                     pr,
                     Term::RDF(VRDF::Type),
-                    Term::OWL(VOWL::AsymmetricProperty),
+                    Term::OWL(VOWL::AsymmetricProperty | VOWL::AntisymmetricProperty),
                 ] => Ok(self
                     .retrieve_to_ope(pr)
                     .map(AsymmetricObjectProperty)
@@ -3036,6 +3036,29 @@ mod test {
         assert_eq!(ont.i().declare_annotation_property().count(), 1);
         assert_eq!(ont.i().declare_object_property().count(), 1);
         assert_eq!(ont.i().symmetric_object_property().count(), 1);
+        assert_eq!(ont.i().class_assertion().count(), 0);
+    }
+
+    #[test]
+    fn legacy_antisymmetric_property_declaration() {
+        // https://github.com/phillord/horned-owl/issues/256
+        // owl:AntisymmetricProperty is the OWL 1.1 working-draft name for
+        // what became owl:AsymmetricProperty in the OWL 2 REC. It must be
+        // read as AsymmetricObjectProperty, not fall through to a spurious
+        // ClassAssertion. See spo_snippet.owl for provenance -- extracted
+        // from the real SPO (Multiscale Skin Physiology Ontology) corpus
+        // file, where ro:has_grain is typed both AntisymmetricProperty and
+        // IrreflexiveProperty.
+        let (ont, incomplete) = read(
+            &mut slurp_rdfont("manual/spo_snippet").as_bytes(),
+            Default::default(),
+        )
+        .unwrap();
+        assert!(incomplete.is_complete());
+
+        let ont: ComponentMappedOntology<_, RcAnnotatedComponent> = ont.into();
+        assert_eq!(ont.i().asymmetric_object_property().count(), 1);
+        assert_eq!(ont.i().irreflexive_object_property().count(), 1);
         assert_eq!(ont.i().class_assertion().count(), 0);
     }
 

--- a/src/ont/owl-rdf/manual/spo_snippet.owl
+++ b/src/ont/owl-rdf/manual/spo_snippet.owl
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  Minimal subset of the 2008 "Multiscale Skin Physiology Ontology"
+  (SPO_lightweight_merged.owl), extracted by hand from a copy retrieved via
+  the horned-roundtrip corpus (corpus/SPO.gz). Reproduces issue #256: the
+  ro:has_grain object property is typed with the legacy OWL 1.1 working-draft
+  term owl:AntisymmetricProperty (renamed owl:AsymmetricProperty in the OWL 2
+  REC), alongside the still-current owl:IrreflexiveProperty. Node names and
+  the triples themselves are copied verbatim from SPO.gz; only the
+  surrounding unrelated axioms have been cut.
+-->
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:ro="http://purl.org/obo/owl/ro#"
+    xml:base="http://www.semanticweb.org/ontologies/2008/8/SPO_lightweight_merged.owl">
+  <owl:Ontology rdf:about=""/>
+
+  <owl:ObjectProperty rdf:about="http://purl.org/obo/owl/ro#has_grain">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AntisymmetricProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#IrreflexiveProperty"/>
+  </owl:ObjectProperty>
+</rdf:RDF>

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -192,6 +192,7 @@ vocabulary_type! {
         (OWL, AnnotatedTarget, true),
         (OWL, Annotation, false),
         (OWL, AnnotationProperty, false),
+        (OWL, AntisymmetricProperty, false),
         (OWL, AssertionProperty, true),
         (OWL, AsymmetricProperty, false),
         (OWL, Axiom, false),
@@ -615,6 +616,10 @@ mod tests {
         assert_eq!(
             OWL::AnnotationProperty.as_ref(),
             "http://www.w3.org/2002/07/owl#AnnotationProperty"
+        );
+        assert_eq!(
+            OWL::AntisymmetricProperty.as_ref(),
+            "http://www.w3.org/2002/07/owl#AntisymmetricProperty"
         );
         assert_eq!(
             OWL::AssertionProperty.as_ref(),


### PR DESCRIPTION
owl:AntisymmetricProperty is the OWL 1.1 working-draft name for what became owl:AsymmetricProperty in the OWL 2 REC. Real-world ontologies (e.g. the OBO Relation Ontology, as used in the 2008 SPO corpus file) still use it via a plain rdf:type triple. Recognise it as a first-class vocab term and map it to AsymmetricObjectProperty, matching how owl:IrreflexiveProperty is already handled.

Closes #256