### PR TITLE
Infer a SubPropertyOf axiom's kind from a known sibling property

### DIFF
--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -2035,21 +2035,30 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         ]).into()
                 },
                 [pr, Term::RDFS(VRDFS::SubPropertyOf), spr] => {
+                    // If spr's kind can't be determined on its own (e.g. an
+                    // undeclared external property), fall back to pr's --
+                    // rdfs:subPropertyOf necessarily relates two properties
+                    // of the same kind, so a known sub-property is evidence
+                    // for its otherwise-unknown super-property's kind, not
+                    // just an unfounded guess.
                     ok_some! {
-                        match self.distinguish_retrieve_property_kind(spr, ic)? {
-                            PropertyExpression::ObjectPropertyExpression(ope) =>
+                        match self
+                            .distinguish_retrieve_property_kind(spr, ic)
+                            .or_else(|| self.distinguish_retrieve_property_kind(pr, ic))?
+                        {
+                            PropertyExpression::ObjectPropertyExpression(_) =>
                                 SubObjectPropertyOf {
-                                    sup: ope,
+                                    sup: self.retrieve_to_ope(spr)?,
                                     sub: self.retrieve_to_sope(pr)?,
                                 }.into(),
-                            PropertyExpression::DataProperty(dp) =>
+                            PropertyExpression::DataProperty(_) =>
                                 SubDataPropertyOf {
-                                    sup: dp,
+                                    sup: self.convert_to_dp(spr)?,
                                     sub: self.convert_to_dp(pr)?
                                 }.into(),
-                            PropertyExpression::AnnotationProperty(ap) =>
+                            PropertyExpression::AnnotationProperty(_) =>
                                 SubAnnotationPropertyOf {
-                                    sup: ap,
+                                    sup: self.convert_to_ap(spr)?,
                                     sub: self.convert_to_ap(pr)?
                                 }.into(),
                         }
@@ -3060,6 +3069,26 @@ mod test {
         assert_eq!(ont.i().asymmetric_object_property().count(), 1);
         assert_eq!(ont.i().irreflexive_object_property().count(), 1);
         assert_eq!(ont.i().class_assertion().count(), 0);
+    }
+
+    #[test]
+    fn sub_property_of_infers_kind_from_known_sibling() {
+        // https://github.com/phillord/horned-owl/issues/257
+        // rdfs:subPropertyOf necessarily relates two properties of the same
+        // kind, so if the super-property's kind can't be determined on its
+        // own (here, dc:terms:alternative is external and never declared),
+        // fall back to the sub-property's known kind instead of dropping
+        // the triple. See edam_bioimaging_snippet.owl for provenance --
+        // extracted from the real EDAM-BIOIMAGING corpus file.
+        let (ont, incomplete) = read(
+            &mut slurp_rdfont("manual/edam_bioimaging_snippet").as_bytes(),
+            Default::default(),
+        )
+        .unwrap();
+        assert!(incomplete.is_complete());
+
+        let ont: ComponentMappedOntology<_, RcAnnotatedComponent> = ont.into();
+        assert_eq!(ont.i().sub_annotation_property_of().count(), 1);
     }
 
     #[test]

--- a/src/ont/owl-rdf/manual/edam_bioimaging_snippet.owl
+++ b/src/ont/owl-rdf/manual/edam_bioimaging_snippet.owl
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  Minimal subset of the EDAM-BIOIMAGING ontology, extracted by hand from a
+  copy retrieved via the horned-roundtrip corpus (corpus/EDAM-BIOIMAGING.gz).
+  Reproduces issue #257: edam:abbreviation is declared owl:AnnotationProperty
+  and is rdfs:subPropertyOf dc:terms:alternative, which is never declared as
+  anything in this file (it is defined externally, in Dublin Core Terms, and
+  not imported). The sub-property's known kind is evidence for the otherwise
+  undeclared super-property's kind. Node names and the triples themselves are
+  copied verbatim from EDAM-BIOIMAGING.gz; only the surrounding unrelated
+  axioms have been cut.
+-->
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xml:base="http://edamontology.org">
+  <owl:Ontology rdf:about=""/>
+
+  <owl:AnnotationProperty rdf:about="http://edamontology.org/abbreviation">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/alternative"/>
+  </owl:AnnotationProperty>
+</rdf:RDF>


### PR DESCRIPTION
rdfs:subPropertyOf necessarily relates two properties of the same kind. If the super-property's kind can't be determined on its own (e.g. an undeclared external property like dc:terms:alternative), fall back to the sub-property's known kind instead of dropping the triple -- inference from a known sibling, matching the pattern already used elsewhere in strict mode (distinguish_property_iri_pair_kind), not a blind guess.

Closes #257