### PR TITLE
Widen SetOntology-typed interfaces to Ontology<A> where only iteration is needed

### DIFF
--- a/src/io/obo/oracle.rs
+++ b/src/io/obo/oracle.rs
@@ -23,7 +23,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::model::RcStr;
+use crate::model::{Ontology, RcStr};
 use crate::ontology::set::SetOntology;
 
 /// Resolve the ROBOT command: `$HORNED_ROBOT`, else `robot` if it runs.
@@ -52,7 +52,7 @@ fn robot_convert(robot: &str, obo: &Path, ofn: &Path) {
 }
 
 /// Render an ontology as the set of its components' canonical debug strings.
-fn components(ont: &SetOntology<RcStr>) -> BTreeSet<String> {
+fn components<O: Ontology<RcStr>>(ont: &O) -> BTreeSet<String> {
     ont.iter().map(|ac| format!("{ac:?}")).collect()
 }
 

--- a/src/io/obo/reader/mod.rs
+++ b/src/io/obo/reader/mod.rs
@@ -134,7 +134,7 @@ mod tests {
 
     use crate::model::{
         AnnotationValue, ClassExpression, Component, Individual, Literal, ObjectPropertyExpression,
-        RcStr,
+        Ontology, RcStr,
     };
     use crate::ontology::set::SetOntology;
 
@@ -194,7 +194,7 @@ mod tests {
 
     /// Render the instance-relevant components in a compact, stable form for
     /// golden comparison.
-    fn render_set(ont: &SetOntology<RcStr>) -> BTreeSet<String> {
+    fn render_set<O: Ontology<RcStr>>(ont: &O) -> BTreeSet<String> {
         ont.iter()
             .map(|ac| match &ac.component {
                 Component::DeclareClass(d) => {
@@ -240,7 +240,7 @@ mod tests {
             .collect()
     }
 
-    fn has_label(ont: &SetOntology<RcStr>, subj: &str, value: &str) -> bool {
+    fn has_label<O: Ontology<RcStr>>(ont: &O, subj: &str, value: &str) -> bool {
         ont.iter().any(|ac| match &ac.component {
             Component::AnnotationAssertion(a) => {
                 matches!(&a.subject, crate::model::AnnotationSubject::IRI(i) if i.as_ref() == subj)

--- a/src/io/obo/writer/mod.rs
+++ b/src/io/obo/writer/mod.rs
@@ -669,7 +669,7 @@ mod tests {
     use std::fs::read_dir;
     use std::path::PathBuf;
 
-    use crate::model::{AnnotatedComponent, RcStr};
+    use crate::model::{AnnotatedComponent, Ontology, RcStr};
     use crate::ontology::component_mapped::ComponentMappedOntology;
     use crate::ontology::set::SetOntology;
 
@@ -682,7 +682,7 @@ mod tests {
         .0
     }
 
-    fn axioms(ont: &SetOntology<RcStr>) -> BTreeSet<String> {
+    fn axioms<O: Ontology<RcStr>>(ont: &O) -> BTreeSet<String> {
         ont.iter().map(|ac| format!("{ac:?}")).collect()
     }
 

--- a/src/ontology/component_mapped.rs
+++ b/src/ontology/component_mapped.rs
@@ -383,22 +383,13 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for ComponentMappedOntology<A, AA>
 
 impl<A: ForIRI, AA: ForIndex<A>> From<SetOntology<A>> for ComponentMappedOntology<A, AA> {
     fn from(so: SetOntology<A>) -> ComponentMappedOntology<A, AA> {
-        let mut amo = ComponentMappedOntology::new();
-        for cmp in so {
-            amo.insert(cmp);
-        }
-        amo
+        so.into_iter().collect::<MutableOntologyAdaptor<_>>().0
     }
 }
 
 impl<A: ForIRI, AA: ForIndex<A>> From<ComponentMappedOntology<A, AA>> for SetOntology<A> {
     fn from(amo: ComponentMappedOntology<A, AA>) -> SetOntology<A> {
-        let mut so = SetOntology::new();
-
-        for cmp in amo {
-            so.insert(cmp);
-        }
-        so
+        amo.into_iter().collect::<MutableOntologyAdaptor<_>>().0
     }
 }
 

--- a/src/ontology/iri_mapped.rs
+++ b/src/ontology/iri_mapped.rs
@@ -335,11 +335,7 @@ impl<A: ForIRI, AA: ForIndex<A>> IntoIterator for IRIMappedOntology<A, AA> {
 
 impl<A: ForIRI, AA: ForIndex<A>> From<SetOntology<A>> for IRIMappedOntology<A, AA> {
     fn from(so: SetOntology<A>) -> IRIMappedOntology<A, AA> {
-        let mut imo = IRIMappedOntology::default();
-        for cmp in so {
-            imo.insert(cmp);
-        }
-        imo
+        so.into_iter().collect::<MutableOntologyAdaptor<_>>().0
     }
 }
 

--- a/src/visitor/immutable.rs
+++ b/src/visitor/immutable.rs
@@ -1,6 +1,5 @@
 /// An immutable `Visit`/`Walk` for Horned-OWL Ontologies.
 use crate::model::*;
-use crate::ontology::set::SetOntology;
 use crate::vocab::Facet;
 use std::collections::BTreeSet;
 use std::marker::PhantomData;
@@ -83,7 +82,7 @@ pub trait Visit<A: ForIRI> {
     fn visit_data_range(&mut self, _: &DataRange<A>) {}
     fn visit_class_expression(&mut self, _: &ClassExpression<A>) {}
     fn visit_ontology_id(&mut self, _: &OntologyID<A>) {}
-    fn visit_set_ontology(&mut self, _: &SetOntology<A>) {}
+    fn visit_set_ontology<O: Ontology<A>>(&mut self, _: &O) {}
     fn visit_option_iri(&mut self, _: &Option<IRI<A>>) {}
     fn visit_annotation_set(&mut self, _: &BTreeSet<Annotation<A>>) {}
     fn visit_class_expression_vec(&mut self, _: &Vec<ClassExpression<A>>) {}
@@ -703,7 +702,7 @@ impl<A: ForIRI, V: Visit<A>> Walk<A, V> {
         self.option_iri(&e.viri);
     }
 
-    pub fn set_ontology(&mut self, e: &SetOntology<A>) {
+    pub fn set_ontology<O: Ontology<A>>(&mut self, e: &O) {
         self.0.visit_set_ontology(e);
         for i in e.iter() {
             self.annotated_component(i);


### PR DESCRIPTION
Several places in the codebase were typed to &SetOntology<A> where the body only used the Ontology<A> trait (e.g. Walk::set_ontology, and a few OBO test/oracle helpers), forcing callers to convert other ontology representations into a SetOntology first even though nothing required it. Widened those to <O: Ontology<A>>.

Also deduplicated the naive SetOntology<->ComponentMappedOntology/IRIMappedOntology From impls through the existing MutableOntologyAdaptor, while leaving the two impls that reuse an already-built internal index (IRIMappedOntology/ConcreteRDFOntology -> SetOntology) untouched, since a generic rewrite would have made those measurably slower.

Closes #259