### PR TITLE
Prefer the longest matching prefix when abbreviating IRIs, matching OWL API

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -16,6 +16,28 @@ use crate::{
     ontology::{component_mapped::ComponentMappedOntology, set::SetOntology},
 };
 
+/// Shrink `iri` against `mapping`, preferring the *longest* matching named
+/// prefix, unlike [`curie::PrefixMapping::shrink_iri`]'s insertion-order
+/// first-match. Matches OWL API's convention (#148).
+///
+/// The default prefix's value isn't exposed by `curie::PrefixMapping`, so it
+/// can't be length-compared here; any named-prefix match wins over it, and
+/// it's used only as a fallback when no named prefix matches.
+pub(crate) fn shrink_iri_longest_match<'a>(
+    mapping: &'a PrefixMapping,
+    iri: &'a str,
+) -> Option<curie::Curie<'a>> {
+    mapping
+        .mappings()
+        .filter_map(|(name, value)| {
+            iri.strip_prefix(value.as_str())
+                .map(|local| (name.as_str(), value.len(), local))
+        })
+        .max_by_key(|(_, len, _)| *len)
+        .map(|(name, _, local)| curie::Curie::new(Some(name), local))
+        .or_else(|| mapping.shrink_iri(iri).ok())
+}
+
 pub enum ResourceType {
     OFN,
     OWX,

--- a/src/io/ofn/writer/as_functional.rs
+++ b/src/io/ofn/writer/as_functional.rs
@@ -956,18 +956,21 @@ fn is_valid_ofn_local_part(s: &str) -> bool {
 /// Abbreviate `iri` against `prefixes` as `prefix:local`, if possible.
 ///
 /// Doesn't use `curie::PrefixMapping::shrink_iri`: its `Display` for a
-/// default-prefix match omits the colon OFN's grammar requires (#230).
+/// default-prefix match omits the colon OFN's grammar requires (#230), and
+/// it picks whichever prefix was inserted first rather than the longest
+/// (most specific) matching one (#148).
+///
 /// Falls back to the full `<IRI>` form when no mapping gives a valid
 /// local part.
 fn shrink_iri_for_ofn<'a>(prefixes: &'a PrefixMapping, iri: &str) -> Option<(&'a str, String)> {
-    for (name, value) in prefixes.mappings() {
-        if let Some(local) = iri.strip_prefix(value.as_str())
-            && is_valid_ofn_local_part(local)
-        {
-            return Some((name.as_str(), local.to_string()));
-        }
-    }
-    None
+    prefixes
+        .mappings()
+        .filter_map(|(name, value)| {
+            let local = iri.strip_prefix(value.as_str())?;
+            is_valid_ofn_local_part(local).then(|| (name.as_str(), value.len(), local.to_string()))
+        })
+        .max_by_key(|(_, len, _)| *len)
+        .map(|(name, _, local)| (name, local))
 }
 
 impl<A: ForIRI> Display for Functional<'_, IRI<A>, A> {
@@ -1306,6 +1309,21 @@ mod tests {
             "Declaration(Class(<http://identifiers.org/mamo#MAMO_0000207>))",
             ofn
         );
+    }
+
+    // Regression test for #148: `eg` is inserted before `egc`, and both are
+    // valid OFN syntax, so the validity check alone can't save this --
+    // insertion-order-first-match would pick the wrong one.
+    #[test]
+    fn test_ofn_prefers_longest_matching_prefix() {
+        let build = Build::new_arc();
+        let mut prefixes = curie::PrefixMapping::default();
+        prefixes.add_prefix("eg", "http://example.com/AB").ok();
+        prefixes.add_prefix("egc", "http://example.com/ABC").ok();
+
+        let decl = DeclareClass(build.class("http://example.com/ABCDEF"));
+        let ofn = format!("{}", decl.as_functional_with_prefixes(&prefixes));
+        assert_eq!("Declaration(Class(egc:DEF))", ofn);
     }
 
     // Regression test for #234: a literal '[' or ']' (legal in an XML

--- a/src/io/omn/writer/as_manchester.rs
+++ b/src/io/omn/writer/as_manchester.rs
@@ -61,37 +61,27 @@ fn is_valid_manchester_local(local: &str) -> bool {
 /// sites: the `Display` path (`write_iri`), the `String`-building path
 /// (`write_iri_to_string`), and the frame-subject renderer in `mod.rs`.
 pub(crate) fn render_iri_to_string(iri: &str, pm: Option<&PrefixMapping>) -> String {
-    if let Some(pm) = pm
-        && let Ok(curie) = pm.shrink_iri(iri)
-    {
-        let s = curie.to_string();
-        // The local name is everything after the first ':' (curie prefixes never
-        // contain a ':').
-        let local = s.split_once(':').map_or(s.as_str(), |(_, l)| l);
-        // Only abbreviate when the local name is a valid Manchester local name.
-        // A version IRI like `http://ex/o/1.0.0` shrinks to `ex:o/1.0.0`, whose
-        // `/` is NOT valid — emitting that abbreviation produces output the reader
-        // cannot re-parse.  A namespace without a name separator (e.g.
-        // `http://e/onto`) shrinks `http://e/onto#A` to `#A`, which is also
-        // invalid — emit the full `<iri>` form instead.
-        if is_valid_manchester_local(local) {
-            if !s.contains(':') {
-                // `shrink_iri` matched curie's separate `set_default()` slot
-                // (issue #233), not a named mapping-table entry -- there's no
-                // backing `Prefix: : <iri>` line, so a bare SimpleIRI here
-                // would be unresolvable. Fall back to the full <iri> form.
-                return format!("<{iri}>");
-            }
-            // A named entry, backed by a real `Prefix:` header line.
-            return if let Some(stripped) = s.strip_prefix(':') {
-                // Empty name -- Display gives ":local"; strip the leading ':'.
-                stripped.to_owned()
+    if let Some(pm) = pm {
+        // Only named entries (`.mappings()`), never curie's default slot
+        // (#233) -- that has no backing header line, so a bare SimpleIRI
+        // would be unresolvable. Among valid matches, prefer the longest
+        // (most specific) prefix, not insertion order (#148).
+        let best = pm
+            .mappings()
+            .filter_map(|(name, value)| {
+                let local = iri.strip_prefix(value.as_str())?;
+                is_valid_manchester_local(local).then_some((name.as_str(), value.len(), local))
+            })
+            .max_by_key(|(_, len, _)| *len);
+
+        if let Some((name, _, local)) = best {
+            return if name.is_empty() {
+                local.to_owned()
             } else {
-                s
+                format!("{name}:{local}")
             };
         }
-        // else: invalid local (digit-leading, empty, contains '#'/'/'/…, ends with '.')
-        // — fall through to the full IRI form.
+        // else: no named prefix has a valid local name -- fall through to <iri>.
     }
     format!("<{iri}>")
 }
@@ -954,6 +944,19 @@ mod tests {
         let mut pm = curie::PrefixMapping::default();
         pm.add_prefix("ex", "http://example.org/").unwrap();
         assert_eq!(c.as_manchester_with_prefixes(&pm).to_string(), "ex:Dog");
+    }
+
+    #[test]
+    fn prefers_longest_matching_prefix() {
+        // Regression test for #148: `eg` is inserted before `egc`, and both
+        // are valid Manchester syntax, so the validity check alone can't save
+        // this -- insertion-order-first-match would pick the wrong one.
+        let b = Build::new_rc();
+        let c = b.class("http://example.com/ABCDEF");
+        let mut pm = curie::PrefixMapping::default();
+        pm.add_prefix("eg", "http://example.com/AB").unwrap();
+        pm.add_prefix("egc", "http://example.com/ABC").unwrap();
+        assert_eq!(c.as_manchester_with_prefixes(&pm).to_string(), "egc:DEF");
     }
 
     #[test]

--- a/src/io/owx/writer.rs
+++ b/src/io/owx/writer.rs
@@ -1,6 +1,7 @@
 use curie::PrefixMapping;
 
 use crate::error::HornedError;
+use crate::io::shrink_iri_longest_match;
 use crate::model::*;
 use crate::ontology::component_mapped::ComponentMappedOntology;
 use crate::ontology::indexed::ForIndex;
@@ -58,12 +59,12 @@ where
 
 /// Add an IRI or AbbreviatedIRI attribute to elem
 fn iri_or_curie(mapping: &PrefixMapping, elem: &mut BytesStart, iri: &str) {
-    match mapping.shrink_iri(&(*iri)[..]) {
-        Ok(curie) => {
+    match shrink_iri_longest_match(mapping, iri) {
+        Some(curie) => {
             let curie = format!("{curie}");
             elem.push_attribute(("IRI", &curie[..]));
         }
-        Err(_) => elem.push_attribute(("IRI", iri)),
+        None => elem.push_attribute(("IRI", iri)),
     }
 }
 
@@ -363,9 +364,9 @@ render! {
     {
         let iri_st: String = self.into();
 
-        match m.shrink_iri(&iri_st[..]) {
-            Ok(curie) => curie.to_string().within(w, m, "IRI"),
-            Err(_) => iri_st.within(w, m, "IRI"),
+        match shrink_iri_longest_match(m, &iri_st[..]) {
+            Some(curie) => curie.to_string().within(w, m, "IRI"),
+            None => iri_st.within(w, m, "IRI"),
         }
     }
 }
@@ -1084,6 +1085,30 @@ mod test {
             assert_eq!(prefix_orig_map, prefix_round_map);
         }
         (ont_orig, prefix_orig, ont_round, prefix_round)
+    }
+
+    // Regression test for #148: `eg` is inserted before `egc` so
+    // insertion-order-first-match would pick the wrong (less specific) one.
+    #[test]
+    fn test_prefers_longest_matching_prefix() {
+        let mut ont = ComponentMappedOntology::new_rc();
+        let build = Build::new();
+        ont.declare(build.class("http://example.com/ABCDEF"));
+
+        let mut prefixes = PrefixMapping::default();
+        prefixes.add_prefix("eg", "http://example.com/AB").unwrap();
+        prefixes
+            .add_prefix("egc", "http://example.com/ABC")
+            .unwrap();
+
+        let mut buf = Vec::new();
+        write(&mut buf, &ont, Some(&prefixes)).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+
+        assert!(
+            s.contains("IRI=\"egc:DEF\""),
+            "expected the longest-matching prefix egc:DEF, got: {s}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #148

`curie::PrefixMapping::shrink_iri` picks whichever registered prefix was inserted first when several match, not the longest (most specific) one -- this is documented, intentional curie-crate behaviour, not a bug. It doesn't match OWL API's convention. This adds longest-match selection across the OWX, OMN, and OFN writers, each falling back to the existing validity/default-prefix handling where relevant. No new validity filtering is added to OWX (strict/lax enforcement there is a separate, not-yet-addressed gap).