### PR TITLE
docs: document OBO support (README syntax list + horned-convert --to)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ with millions of terms.
   + [x] OWL/XML
   + [x] Functional Syntax
   + [x] Manchester Syntax
+  + [x] OBO Flat File
 + A [visitor](https://en.wikipedia.org/wiki/Visitor_pattern) trait to navigate and manipulate ontologies
 + Traits and implementations for several types of ontologies
 

--- a/horned-bin/src/bin/horned_convert.rs
+++ b/horned-bin/src/bin/horned_convert.rs
@@ -32,7 +32,7 @@ pub(crate) fn app(name: &str) -> App<'static> {
                 .takes_value(true)
                 .required(true)
                 .help(
-                    "The format to convert to: owx, ofn, omn, owl, \
+                    "The format to convert to: owx, ofn, omn, obo, owl, \
                      or any RDF syntax oxrdfio supports (ttl, nt, nq, trig, jsonld, n3)",
                 ),
         )


### PR DESCRIPTION
OBO read/write landed in #217, but two docs still don't reflect it. This is docs-only, no behavior change.

**1. README supported-syntaxes list** omitted OBO — added `[x] OBO Flat File` alongside RDF/XML, OWL/XML, Functional, and Manchester.

**2. `horned-convert --to` help text** omitted `obo`, though `--to obo` already works (`horned-bin`'s `write()` dispatches `"obo" => horned_owl::io::obo::write(...)`). Added it.

Verified on `devel`:

```
$ horned-convert --help
    --to <to>    The format to convert to: owx, ofn, omn, obo, owl, or any RDF syntax
                 oxrdfio supports (ttl, nt, nq, trig, jsonld, n3)

$ horned-convert onto.ttl --to obo
ontology: http://x
...
```