### PR TITLE
fix(obo): don't treat short ids starting with 'http' as absolute IRIs

### DIFF
--- a/src/io/obo/reader/from_pair.rs
+++ b/src/io/obo/reader/from_pair.rs
@@ -35,6 +35,14 @@ use crate::model::{
 
 pub(crate) const OBO_BASE: &str = "http://purl.obolibrary.org/obo/";
 pub(crate) const OIO: &str = "http://www.geneontology.org/formats/oboInOwl#";
+
+/// Whether an OBO `ontology:` value is already an absolute `http(s)` IRI (used
+/// as-is) rather than a short id to expand under `OBO_BASE`. Testing a bare
+/// `http` prefix wrongly matched short ids like `httptest`/`httpfoo`, leaving a
+/// relative ontology IRI.
+fn is_http_iri(s: &str) -> bool {
+    s.starts_with("http://") || s.starts_with("https://")
+}
 const RDFS_LABEL: &str = "http://www.w3.org/2000/01/rdf-schema#label";
 const RDFS_COMMENT: &str = "http://www.w3.org/2000/01/rdf-schema#comment";
 const IAO_DEF: &str = "http://purl.obolibrary.org/obo/IAO_0000115";
@@ -356,7 +364,7 @@ pub fn scan_header<A: ForIRI>(
                 onto_ns = values
                     .first()
                     .map(|v| v.as_str().trim())
-                    .and_then(|o| (!o.starts_with("http")).then(|| format!("{OBO_BASE}{o}#")));
+                    .and_then(|o| (!is_http_iri(o)).then(|| format!("{OBO_BASE}{o}#")));
             }
             _ => {}
         }
@@ -381,7 +389,7 @@ pub fn header_to_components<A: ForIRI>(
         match tag {
             Rule::OntologyTag => {
                 if let Some(o) = val(0) {
-                    let iri = if o.starts_with("http") {
+                    let iri = if is_http_iri(o) {
                         o.to_string()
                     } else {
                         format!("{OBO_BASE}{o}.owl")

--- a/src/io/obo/reader/mod.rs
+++ b/src/io/obo/reader/mod.rs
@@ -321,6 +321,27 @@ mod tests {
     }
 
     #[test]
+    fn ontology_short_id_starting_with_http_is_expanded() {
+        // Regression: an `ontology:` short id that merely starts with "http"
+        // (e.g. `httptest`) must still expand to the OBO PURL, not be treated as
+        // an already-absolute IRI and left relative (`<httptest>`).
+        let ont = read("ontology: httptest\n\n[Term]\nid: GO:0001\nname: x\n");
+        let want = "http://purl.obolibrary.org/obo/httptest.owl";
+        assert!(ont.iter().any(|ac| matches!(&ac.component,
+            Component::OntologyID(o) if o.iri.as_ref().map(|i| i.as_ref()) == Some(want))));
+    }
+
+    #[test]
+    fn ontology_absolute_iri_is_used_verbatim() {
+        // A real `http(s)://` IRI is used as-is, not re-expanded.
+        let want = "http://example.org/my-onto";
+        let doc = format!("ontology: {want}\n\n[Term]\nid: GO:0001\nname: x\n");
+        let ont = read(&doc);
+        assert!(ont.iter().any(|ac| matches!(&ac.component,
+            Component::OntologyID(o) if o.iri.as_ref().map(|i| i.as_ref()) == Some(want))));
+    }
+
+    #[test]
     fn synonym_scope_maps_to_property() {
         let doc = "[Term]\nid: GO:0008150\nsynonym: \"bp\" EXACT [GOC:x]\n";
         let ont = read(doc);


### PR DESCRIPTION
## Bug

The OBO reader expands an `ontology:` header value to an OBO PURL *unless* it looks like it's already an IRI — but the guard was `o.starts_with("http")`, which matches any short id beginning with `http`:

```rust
let iri = if o.starts_with("http") {   // matches "httptest", "httpfoo", …
    o.to_string()
} else {
    format!("{OBO_BASE}{o}.owl")
};
```

So `ontology: httptest` yields a **relative** ontology IRI `<httptest>` instead of `http://purl.obolibrary.org/obo/httptest.owl`. That relative IRI then can't be serialized/loaded as N-Triples ("No scheme found in an absolute IRI"). Simple ids (`go`, `myonto`) and even hyphenated ones (`foo-bar`) are unaffected — it's specifically the `http` prefix.

The same loose guard is used for the ontology **namespace** derivation (bare-relation resolution), so `httptest` also broke `obo/<id>#<rel>`.

## Fix

Require a real scheme via a small `is_http_iri` helper (`http://` / `https://`), applied to both the ontology IRI and the namespace derivation.

```rust
fn is_http_iri(s: &str) -> bool {
    s.starts_with("http://") || s.starts_with("https://")
}
```

## Tests

Added to `io::obo::reader::tests`:
- `ontology_short_id_starting_with_http_is_expanded` — `ontology: httptest` → `…/obo/httptest.owl`.
- `ontology_absolute_iri_is_used_verbatim` — a real `http://…` IRI is used as-is.

Full `io::obo` suite passes (24 tests).

## Note

A similar bare-`http` guard exists for Typedef shorthand-id detection (`from_pair.rs` ~L1097). That's a separate concern (shorthand vs ontology-IRI) so I left it out of this PR — happy to address separately if you'd like.