### PR TITLE
Read owl:AllDisjointProperties

### DIFF
--- a/src/io/rdf/reader.rs
+++ b/src/io/rdf/reader.rs
@@ -1863,6 +1863,57 @@ impl<'a, A: ForIRI, AA: ForIndex<A>, O: RDFOntology<A, AA>> OntologyParser<'a, A
                         ).into()
                     }
                 }
+                // The writer already emits this form for more than two
+                // operands (see `members` in io/rdf/writer.rs), so without
+                // this arm horned-owl cannot read back what it writes.
+                //
+                // `retrieve_to_seq` takes a fn pointer and so cannot
+                // carry `ic`, which `distinguish_retrieve_property_kind`
+                // needs. The sequence is therefore resolved by hand, and
+                // deliberately only removed from `bnode_seq` once every
+                // member has resolved: declarations may arrive in a
+                // later pass, exactly as `retrieve_to_ce_seq` guards
+                // against.
+                [
+                    [_, Term::OWL(VOWL::Members), Term::BNode(bnodeid)], //:
+                    [_, Term::RDF(VRDF::Type), Term::OWL(VOWL::AllDisjointProperties)],
+                ] => {
+                    ok_some! {
+                        {
+                            let terms = self.bnode_seq.get(bnodeid)?.clone();
+                            let pes: Vec<_> = terms
+                                .iter()
+                                .map(|t| self.distinguish_retrieve_property_kind(t, ic))
+                                .collect::<Option<Vec<_>>>()?;
+
+                            let mut ops = vec![];
+                            let mut dps = vec![];
+                            for pe in pes {
+                                match pe {
+                                    PropertyExpression::ObjectPropertyExpression(ope) =>
+                                        ops.push(ope),
+                                    PropertyExpression::DataProperty(dp) => dps.push(dp),
+                                    // An annotation property cannot be
+                                    // disjoint with anything in OWL 2 DL.
+                                    PropertyExpression::AnnotationProperty(_) => return None,
+                                }
+                            }
+
+                            let axiom: Component<A> = if dps.is_empty() && !ops.is_empty() {
+                                DisjointObjectProperties(ops).into()
+                            } else if ops.is_empty() && !dps.is_empty() {
+                                DisjointDataProperties(dps).into()
+                            } else {
+                                // Mixed, or empty. Leave the triples in
+                                // IncompleteParse rather than guess.
+                                return None;
+                            };
+
+                            self.bnode_seq.remove(bnodeid);
+                            axiom
+                        }
+                    }
+                }
                 _ => Ok(None),
             };
 
@@ -2757,6 +2808,72 @@ mod test {
     use crate::ontology::component_mapped::RcComponentMappedOntology;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+
+    /// The n-ary property disjointness form.
+    ///
+    /// The existing fixtures only exercise the two-operand
+    /// `owl:propertyDisjointWith` shape, so `owl:AllDisjointProperties`
+    /// went unread even though the writer emits it. `read_ok` asserts the
+    /// parse is complete, so each of these fails on a reader that leaves
+    /// the triples in `IncompleteParse`.
+    fn nary(body: &str) -> ConcreteRDFOntology<RcStr, Rc<AnnotatedComponent<RcStr>>> {
+        let doc = format!(
+            r##"<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xml:base="http://www.example.com/iri">
+  <owl:Ontology rdf:about="http://www.example.com/iri"/>
+{body}
+</rdf:RDF>"##
+        );
+        read_ok(&mut doc.as_bytes())
+    }
+
+    #[test]
+    fn all_disjoint_object_properties() {
+        let ont: ComponentMappedOntology<RcStr, Rc<AnnotatedComponent<RcStr>>> = nary(
+            r##"  <owl:ObjectProperty rdf:about="#p"/>
+  <owl:ObjectProperty rdf:about="#q"/>
+  <owl:ObjectProperty rdf:about="#r"/>
+  <owl:AllDisjointProperties>
+    <owl:members rdf:parseType="Collection">
+      <owl:ObjectProperty rdf:about="#p"/>
+      <owl:ObjectProperty rdf:about="#q"/>
+      <owl:ObjectProperty rdf:about="#r"/>
+    </owl:members>
+  </owl:AllDisjointProperties>"##,
+        )
+        .into();
+
+        assert_eq!(ont.i().disjoint_object_properties().count(), 1);
+        assert_eq!(
+            ont.i().disjoint_object_properties().next().unwrap().0.len(),
+            3
+        );
+    }
+
+    #[test]
+    fn all_disjoint_data_properties() {
+        let ont: ComponentMappedOntology<RcStr, Rc<AnnotatedComponent<RcStr>>> = nary(
+            r##"  <owl:DatatypeProperty rdf:about="#p"/>
+  <owl:DatatypeProperty rdf:about="#q"/>
+  <owl:DatatypeProperty rdf:about="#r"/>
+  <owl:AllDisjointProperties>
+    <owl:members rdf:parseType="Collection">
+      <owl:DatatypeProperty rdf:about="#p"/>
+      <owl:DatatypeProperty rdf:about="#q"/>
+      <owl:DatatypeProperty rdf:about="#r"/>
+    </owl:members>
+  </owl:AllDisjointProperties>"##,
+        )
+        .into();
+
+        assert_eq!(ont.i().disjoint_data_properties().count(), 1);
+        assert_eq!(
+            ont.i().disjoint_data_properties().next().unwrap().0.len(),
+            3
+        );
+    }
 
     fn read_ok<R: BufRead>(
         bufread: &mut R,


### PR DESCRIPTION
The RDF reader has no match arm for `owl:AllDisjointProperties`. It parses without error and produces no axiom; the triples are left in `IncompleteParse`.

Unlike the class case, this is a round trip failure inside the crate rather than a gap in what it accepts from elsewhere: **the writer emits this form and the reader cannot read it back.**

> Narrowed. This PR originally also covered `owl:AllDisjointClasses`, which duplicated #289. I missed that PR when I opened this one. #289 handles the class case and does more than I had (it fixes the writer as well), so the class half has been dropped from here. The two are independent and either can land first: `OWL::AllDisjointProperties` is already in `vocab.rs`, so this touches only the reader.

### The round trip

`DisjointObjectProperties` and `DisjointDataProperties` both render through

```rust
members(f, ng, OWL::PropertyDisjointWith, OWL::AllDisjointProperties, &self.0)
```

(`src/io/rdf/writer.rs:782-804`), so for more than two operands horned-owl writes a construct it cannot parse.

Measured on `devel` at 48d9523, Turtle input with `config.rdf.format = Some(RdfFormat::Turtle)`:

| Input | Axioms read (excluding declarations) | `IncompleteParse` |
| --- | ---: | --- |
| `[] a owl:AllDisjointProperties ; owl:members ( :p :q :r ) .` | 0 | 1 bnode group, 1 bnode seq |

### The change

One match arm in `src/io/rdf/reader.rs`, beside the existing `owl:AllDifferent` ones.

It resolves the sequence by hand rather than through `retrieve_to_seq`, which takes a `fn` pointer and so cannot carry `ic`, which `distinguish_retrieve_property_kind` needs. It removes the sequence from `bnode_seq` only once every member has resolved, since declarations may arrive in a later pass; that is the same hazard `retrieve_to_ce_seq` already guards against. A mixed object and data member list, or an annotation property, returns `None` and leaves the triples in `IncompleteParse` rather than guessing.

### Tests

The existing fixtures only exercise the two operand `owl:propertyDisjointWith` shape, which is why this was not caught. Two tests are added, one for object properties and one for data properties, so both branches of the object/data split are covered.

They use `read_ok`, which already asserts the parse is complete, so each fails on the unpatched reader for the right reason:

```
test io::rdf::reader::test::all_disjoint_object_properties ... FAILED
test io::rdf::reader::test::all_disjoint_data_properties ... FAILED
thread '...' panicked at src/io/rdf/reader.rs:2859:9:
assertion failed: incomp.is_complete()
```

I used inline RDF/XML rather than adding files under `src/ont/`. Happy to convert them to fixtures if that fits the project's conventions better.

I also have an equivalent test for the class case, written before this PR was narrowed and verified the same way. I have offered it on #289, since that is where it belongs.

### Verification

- `cargo test`: 1524 pass, 4 fail. Baseline on `devel` is 1522 pass, 4 fail; the delta is the two new tests. The four failures are the pre-existing `bubo_test` cases, which need `wget` and fail identically before and after on this machine.
- `cargo clippy --all-targets`: 8 warnings, identical to baseline. None are from this change.
- `cargo fmt --check`: clean.

### On a more general fix

You mentioned on #289 that you may want something more general than a special case for one match. Worth noting that this arm has the same shape as the `owl:AllDifferent` ones directly above it and as #289's class arm: a two triple blank node pattern, a typed sequence, one axiom. If those collapse into a general mechanism, this should collapse into it too rather than being kept as a third special case.