### PR TITLE
fix(grammar): accept IRIs with an empty path (#292)

### DIFF
--- a/src/grammars/obo/rfc3987.pest
+++ b/src/grammars/obo/rfc3987.pest
@@ -25,7 +25,7 @@ RFC3987_IriPathAbempty  = ${ ("/" ~ RFC3987_IriSegment)+ }
 RFC3987_IriPathAbsolute = ${ "/" ~ (RFC3987_IriSegmentNz ~ ("/" ~ RFC3987_IriSegment)*)? }
 RFC3987_IriPathNoScheme = ${ RFC3987_IriSegmentNzNc ~ ("/" ~ RFC3987_IriSegment)* }
 RFC3987_IriPathRootless = ${ RFC3987_IriSegmentNz ~ ("/" ~ RFC3987_IriSegment)* }
-RFC3987_IriPathEmpty    = ${ "0" ~ RFC3987_IriIpChar }
+RFC3987_IriPathEmpty    = ${ "" }
 
 RFC3987_IriSegment     = @{ RFC3987_IriIpChar* }
 RFC3987_IriSegmentNz   = @{ RFC3987_IriIpChar+ }

--- a/src/grammars/rfc3987.pest
+++ b/src/grammars/rfc3987.pest
@@ -25,7 +25,7 @@ RFC3987_IriPathAbempty  = ${ ("/" ~ RFC3987_IriSegment)+ }
 RFC3987_IriPathAbsolute = ${ "/" ~ (RFC3987_IriSegmentNz ~ ("/" ~ RFC3987_IriSegment)*)? }
 RFC3987_IriPathNoScheme = ${ RFC3987_IriSegmentNzNc ~ ("/" ~ RFC3987_IriSegment)* }
 RFC3987_IriPathRootless = ${ RFC3987_IriSegmentNz ~ ("/" ~ RFC3987_IriSegment)* }
-RFC3987_IriPathEmpty    = ${ "0" ~ RFC3987_IriIpChar }
+RFC3987_IriPathEmpty    = ${ "" }
 
 RFC3987_IriSegment     = @{ RFC3987_IriIpChar* }
 RFC3987_IriSegmentNz   = @{ RFC3987_IriIpChar+ }

--- a/tests/rfc3987_empty_path.rs
+++ b/tests/rfc3987_empty_path.rs
@@ -1,0 +1,38 @@
+//! Regression test for phillord/horned-owl#292.
+//!
+//! RFC 3986 defines `path-empty = 0<pchar>`, where `0<pchar>` is ABNF for *zero*
+//! repetitions, i.e. the empty string. Any IRI with an empty path — `<urn:>`,
+//! `<mailto:>`, `<tel:>` — must therefore parse.
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+
+fn parses(iri: &str) -> bool {
+    let src = format!("Prefix(:=<{iri}>)\nOntology( Declaration(Class(:A)) )\n");
+    let r: Result<(SetOntology<RcStr>, _), _> =
+        read(&mut src.as_bytes(), ParserConfiguration::default());
+    r.is_ok()
+}
+
+#[test]
+fn empty_path_iris_parse() {
+    for iri in ["urn:", "mailto:", "tel:"] {
+        assert!(parses(iri), "<{iri}> must parse (RFC 3986 path-empty)");
+    }
+}
+
+#[test]
+fn non_empty_path_iris_still_parse() {
+    for iri in ["urn:x", "http://ex.org/", "http://ex.org/a/b#c", "mailto:a@b.org"] {
+        assert!(parses(iri), "<{iri}> regressed");
+    }
+}
+
+#[test]
+fn malformed_iris_are_still_rejected() {
+    for iri in ["", ":", "1http://ex.org/"] {
+        assert!(!parses(iri), "<{iri}> must NOT parse");
+    }
+}


### PR DESCRIPTION
Closes #292.

## The bug

RFC 3986 defines the empty path as:

```abnf
path-empty = 0<pchar>
```

`0<pchar>` is ABNF for *zero* repetitions — the empty string. It was transcribed as a literal `"0"` followed by a pchar:

```pest
RFC3987_IriPathEmpty = ${ "0" ~ RFC3987_IriIpChar }
```

so the rule matches the two-character string `0a` and never matches empty. `RFC3987_IriHierPart` lists it as its only empty-path alternative, so every IRI with an empty path fails to parse:

```
<urn:>            FAIL      expected RFC3987_IriHierPart
<mailto:>         FAIL
<tel:>            FAIL
<urn:x>           ok
<http://ex.org/>  ok
```

## The fix

Make the rule match empty. `pest` accepts an empty string literal, so it is a one-token change.

**Both copies of the grammar carry the defect, and they feed different readers** — #292 names only the first:

* `src/grammars/rfc3987.pest` → the **OFN** and **OMN** readers
* `src/grammars/obo/rfc3987.pest` → the **OBO** reader

Fixing only the file named in the issue would leave the OBO reader broken.

`RFC3987_IriPathEmpty` is the **last** alternative in both `RFC3987_IriHierPart` and `RFC3987_IriPath`, and `pest`'s alternation is ordered, so an epsilon-matching rule there cannot shadow the alternatives before it.

## Test

`tests/rfc3987_empty_path.rs` asserts three things: the empty-path forms parse, non-empty paths still parse, and malformed IRIs (`""`, `":"`, `"1http://ex.org/"`) are still rejected.

## Measured

Against `devel` at 48d9523, `cargo test --no-fail-fast`:

| | passed | failed |
|---|---:|---:|
| before | 1709 | 7 |
| after | 1710 | 6 |

The delta is exactly the new test: before, `empty_path_iris_parse` fails; after, it passes.

**Correction to an earlier version of this description.** It said the other six "fail identically on pristine `devel`", which was true on my machine and misleading about CI. They are local-environment artifacts, not upstream failures — the four `reparse_*` round-trips need the fixtures `make fetch_bubo` pulls, which your workflow does as step 5 and I had not run; `resolve::test::simple_iri` and the `horned-corpus` version test (which asserts it is *not* running inside a git repository) are likewise local. **CI on this PR is green.** The before/after comparison above is still valid — same machine, same conditions, one variable — but read it as a delta, not as a claim about your test suite's health.

## Heads-up, unrelated to this PR

`cargo build --all-features` does not compile on `devel` before or after this change — five `quick-xml` 0.37.5 API errors in `src/io/owx/reader.rs` (`NsReader::decode` is gone; `expand_curie_maybe` now gets `&_` where it wants `Cow<'_, str>`). This never fires in `pre-commit`, which does not build with all features — so it was **not** the cause of this PR's earlier red check (that was my test file missing `cargo fmt`, since fixed). Mentioning it only because it is real and unreported. Happy to open it separately.

